### PR TITLE
Fix a bug where session that have not been loaded on sign_out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v 0.8.1
+
+* Fix a bug with logout where it was not checking the session, only the assigns
+  This meant that if you had not verified the session the token would not be
+  revoked.
+
 # v 0.7.1
 
 * Adds basic Phoenix controller helpers

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ mix.deps
 defp deps do
   [
     # ...
-    {:guardian, "~> 0.8.0"}
+    {:guardian, "~> 0.8.1"}
     # ...
   ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Guardian.Mixfile do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1"
   @url "https://github.com/ueberauth/guardian"
   @maintainers ["Daniel Neighman", "Sonny Scroggin", "Sean Callan"]
 

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -119,19 +119,23 @@ defmodule Guardian.PlugTest do
 
   test "sign_out/1", context do
     conn = conn_with_fetched_session(context.conn)
-    |> Guardian.Plug.sign_in(%{ user: "here" }, :token)
+      |> Guardian.Plug.sign_in(%{ user: "here" }, :token)
 
     assert Guardian.Plug.current_resource(conn) == %{ user: "here" }
 
     cleared_conn = conn
-    |> Plug.Conn.assign(Guardian.Keys.claims_key(:default), %{ claims: "yeah" })
-    |> Plug.Conn.assign(Guardian.Keys.claims_key(:secret), %{ claims: "yeah" })
-    |> Plug.Conn.assign(Guardian.Keys.resource_key(:default), "resource")
-    |> Plug.Conn.assign(Guardian.Keys.resource_key(:secret), "resource")
-    |> Plug.Conn.assign(Guardian.Keys.jwt_key(:default), "token")
-    |> Plug.Conn.assign(Guardian.Keys.jwt_key(:secret), "token")
-    |> Guardian.Plug.sign_out
+      |> Plug.Conn.put_session(Guardian.Keys.base_key(:default), "default jwt")
+      |> Plug.Conn.put_session(Guardian.Keys.base_key(:secret), "secret jwt")
+      |> Plug.Conn.assign(Guardian.Keys.claims_key(:default), %{ claims: "yeah" })
+      |> Plug.Conn.assign(Guardian.Keys.claims_key(:secret), %{ claims: "yeah" })
+      |> Plug.Conn.assign(Guardian.Keys.resource_key(:default), "resource")
+      |> Plug.Conn.assign(Guardian.Keys.resource_key(:secret), "resource")
+      |> Plug.Conn.assign(Guardian.Keys.jwt_key(:default), "token")
+      |> Plug.Conn.assign(Guardian.Keys.jwt_key(:secret), "token")
+      |> Guardian.Plug.sign_out
 
+    assert Plug.Conn.get_session(cleared_conn, Guardian.Keys.base_key(:default)) == nil
+    assert Plug.Conn.get_session(cleared_conn, Guardian.Keys.base_key(:secret)) == nil
     assert cleared_conn.assigns[Guardian.Keys.claims_key(:default)] == nil
     assert cleared_conn.assigns[Guardian.Keys.claims_key(:secret)] == nil
     assert cleared_conn.assigns[Guardian.Keys.resource_key(:default)] == nil


### PR DESCRIPTION
If more than one location is logged in to the session, but have not
yet been loaded, the associated tokens were not being revoked even
though the session was cleared.