### PR TITLE
Refactored tests to use the Guardian.Plug helper methods for working with claims, resources and tokens.

### DIFF
--- a/test/guardian/plug/ensure_authenticated_test.exs
+++ b/test/guardian/plug/ensure_authenticated_test.exs
@@ -2,7 +2,6 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  alias Guardian.Keys
   alias Guardian.Plug.EnsureAuthenticated
 
   defmodule TestHandler do
@@ -18,7 +17,7 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
 
   test "it validates claims and calls through if the claims are ok" do
     claims = %{ "aud" => "token", "sub" => "user1" }
-    conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
+    conn = conn(:get, "/foo") |> Guardian.Plug.set_claims({ :ok, claims })
     opts = EnsureAuthenticated.init(handler: @expected_failure, aud: "token")
     ensured_conn = EnsureAuthenticated.call(conn, opts)
     assert ensured_conn.assigns[:guardian_spec] == nil
@@ -26,7 +25,7 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
 
   test "it validates claims and fails if the claims do not match" do
     claims = %{ "aud" => "oauth", "sub" => "user1" }
-    conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key, {:ok, claims})
+    conn = conn(:get, "/foo") |> Guardian.Plug.set_claims({:ok, claims})
     opts = EnsureAuthenticated.init(handler: @expected_failure, aud: "token")
     ensured_conn = EnsureAuthenticated.call(conn, opts)
     assert ensured_conn.assigns[:guardian_spec] == :unauthenticated
@@ -34,14 +33,14 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
 
   test "it does not call on failure when there is a session at the default location" do
     claims = %{ "aud" => "token", "sub" => "user1" }
-    conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
+    conn = conn(:get, "/foo") |> Guardian.Plug.set_claims({ :ok, claims })
     ensured_conn = EnsureAuthenticated.call(conn, @failure)
     assert ensured_conn.assigns[:guardian_spec] == nil
   end
 
   test "it does not call on failure when there is a session at the specific location" do
     claims = %{ "aud" => "token", "sub" => "user1" }
-    conn = conn(:get, "/foo") |> Plug.Conn.assign(Keys.claims_key(:secret), {:ok, claims})
+    conn = conn(:get, "/foo") |> Guardian.Plug.set_claims({:ok, claims}, :secret)
     ensured_conn = EnsureAuthenticated.call(conn, %{handler: {@expected_failure, :unauthenticated}, key: :secret})
     assert ensured_conn.assigns[:guardian_spec] == nil
   end

--- a/test/guardian/plug/ensure_permissions_test.exs
+++ b/test/guardian/plug/ensure_permissions_test.exs
@@ -2,7 +2,6 @@ defmodule Guardian.Plug.EnsurePermissionTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  alias Guardian.Keys
   alias Guardian.Plug.EnsurePermissions
 
   defmodule TestHandler do
@@ -23,7 +22,7 @@ defmodule Guardian.Plug.EnsurePermissionTest do
     claims = %{ "pem" => %{ "default" => pems } }
 
     expected_conn = conn(:get, "/get")
-    |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
+    |> Guardian.Plug.set_claims({ :ok, claims })
     |> Plug.Conn.fetch_query_params
     |> EnsurePermissions.call(opts)
 
@@ -37,7 +36,7 @@ defmodule Guardian.Plug.EnsurePermissionTest do
     claims = %{ "pem" => %{ "default" => pems } }
 
     expected_conn = conn(:get, "/get")
-    |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
+    |> Guardian.Plug.set_claims({ :ok, claims })
     |> Plug.Conn.fetch_query_params
     |> EnsurePermissions.call(opts)
 
@@ -51,7 +50,7 @@ defmodule Guardian.Plug.EnsurePermissionTest do
     claims = %{ "pem" => %{ "default" => pems } }
 
     expected_conn = conn(:get, "/get")
-    |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
+    |> Guardian.Plug.set_claims({ :ok, claims })
     |> Plug.Conn.fetch_query_params
     |> EnsurePermissions.call(opts)
 
@@ -66,7 +65,7 @@ defmodule Guardian.Plug.EnsurePermissionTest do
     claims = %{ "pem" => %{ "default" => pems, "other" => other_pems } }
 
     expected_conn = conn(:get, "/get")
-    |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
+    |> Guardian.Plug.set_claims({ :ok, claims })
     |> Plug.Conn.fetch_query_params
     |> EnsurePermissions.call(opts)
 
@@ -81,7 +80,7 @@ defmodule Guardian.Plug.EnsurePermissionTest do
     claims = %{ "pem" => %{ "default" => pems, "other" => other_pems } }
 
     expected_conn = conn(:get, "/get")
-    |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
+    |> Guardian.Plug.set_claims({ :ok, claims })
     |> Plug.Conn.fetch_query_params
     |> EnsurePermissions.call(opts)
 
@@ -96,7 +95,7 @@ defmodule Guardian.Plug.EnsurePermissionTest do
     claims = %{ "pem" => %{ "default" => pems, "other" => other_pems } }
 
     expected_conn = conn(:get, "/get")
-    |> Plug.Conn.assign(Keys.claims_key, { :ok, claims })
+    |> Guardian.Plug.set_claims({ :ok, claims })
     |> Plug.Conn.fetch_query_params
     |> EnsurePermissions.call(opts)
 


### PR DESCRIPTION
This refactoring will make it much easier to store guardian attributes in private instead of in the assigns hash (issue #80). The only tests that still directly reference the assigns hash are `test/guardian/plug/ensure_permissions_test.exs` and `test/guardian/plug/ensure_permissions_test.exs`. I didn't update these because I wasn't sure what `conn.assigns[:guardian_spec]` did, and there wasn't a pre-built accessor for it. I'd be happy to also remove these references if you had and suggestions on how you'd like it done.

Once this is merged, I should be able to do the refactoring for #80 without having to change any tests.