### PR TITLE
Refactored Guardian.encode_and_sign/3

### DIFF
--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -127,6 +127,12 @@ defmodule GuardianTest do
     assert claims["some"] == "thing"
   end
 
+  test "encode_and_sign with a serializer error" do
+    { :error, reason } = Guardian.encode_and_sign(%{error: :unknown})
+
+    assert reason
+  end
+
   test "revoke" do
     {:ok, jwt, claims} = Guardian.encode_and_sign("thinger", "my_type", some: "thing")
     assert Guardian.revoke!(jwt, claims) == :ok


### PR DESCRIPTION
I was having a difficult time trying to figure out how the claims are built, so I did some refactoring on the `Guardian.encode_and_sign/3` function. I isolated the claim building functionality into a single private method and wrapped calling the callback hooks in some easier to call method names. All of the tests pass, and I added an additional test for when the serializer fails to generate a token for a given model.