### PR TITLE
Provide a Guardian.Phoenix.Socket module to make it easier to do sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v 0.10.0
+
+* Add a Guardian.Phoenix.Socket module and refactor Guardian.Channel
+
 # v 0.9.1
 
 * Stop compiling permissions. This leads to weird bugs when permissions are

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ someone joins a topic.
 To authenticate the initial connect there's a couple of options.
 
 1. Automatically authenticate
-2. Autehtnticate with more control manually.
+2. Authenticate with more control manually.
 
 To automatcially authenticate `use` the Guardian.Phoenix.Socket module in your
 socket.
@@ -522,20 +522,20 @@ defmodule MyApp.UsersChannel do
   def join(_room, %{"guardian_token" => token}, socket) do
     case sign_in(socket, token) do
       {:ok, authed_socket, _guardian_params} ->
-        {:ok, %{ message: "Joined" }, authed_socket}
+        {:ok, %{message: "Joined"}, authed_socket}
       {:error, reason} ->
         # handle error
     end
   end
 
   def join(room, _, socket) do
-    { :error,  :authentication_required }
+    {:error,  :authentication_required}
   end
 
   def handle_in("ping", _payload, socket) do
     user = current_resource(socket)
-    broadcast socket, "pong", %{ message: "pong", from: user.email }
-    { :noreply, socket }
+    broadcast(socket, "pong", %{message: "pong", from: user.email})
+    {:noreply, socket}
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -438,18 +438,94 @@ defmodule MyApp.MyController do
 end
 ```
 
+### Phoenix Sockets
+
+Guardian provides integration into the Phoenix channels API to provide
+authentication. You can choose to authenticate either on `connect` or every time
+someone joins a topic.
+
+To authenticate the initial connect there's a couple of options.
+
+1. Automatically authenticate
+2. Autehtnticate with more control manually.
+
+To automatcially authenticate `use` the Guardian.Phoenix.Socket module in your
+socket.
+
+```elixir
+defmodule MyApp.UsersSocket do
+  use Phoenix.Socket
+  use Guardian.Phoenix.Socket
+
+  def connect(_params, socket) do
+    # if we get here, we did not authenticate
+    :error
+  end
+end
+```
+
+Connection authentication requires a `guardian_token` parameter to be provided
+which is the JWT. If this is present, Guardian.Phoenix.Socket will authenticate
+the connection and carry on or return an `:error` and not allow the connection.
+
+On the javascript side provide your token when you connect.
+
+```javascript
+let socket = new Socket("/ws");
+socket.connect({guardian_token: jwt});
+```
+
+This works fine when all connections should be authenticated. In the case where
+you want some of them to be, you can manually sign in.
+
+```elixir
+defmodule MyApp.UsersSocket do
+  use Phoenix.Socket
+  import Guardian.Phoenix.Socket
+
+  def connect(%{"guardian_token" => jwt} = params, socket) do
+    case sign_in(socket, jwt) do
+      {:ok, authed_socket, guardian_params} ->
+        {:ok, authed_socket}
+      _ ->
+        #unauthenticated socket
+        {:ok, socket}
+    end
+  end
+
+  def connect(_params, socket) do
+    # handle unauthenticated connection
+  end
+end
+```
+
+Once you have an authenticated socket you can get the information from it:
+
+```elixir
+claims = Guardian.Phoenix.Socket.current_claims(socket)
+jwt = Guardian.Phoenix.Socket.current_token(socket)
+user = Guardian.Phoenix.Socket.current_resource(socket)
+```
+
+If you need even more control, you can use the helpers provided by
+Phoenix.Guardian.Socket inside your Channel.
+
 ### Phoenix Channels
 
-Guardian uses JWTs to make the integration of authentication management as
-seamless as possible. Channel integration is part of that.
+We can use the Guardian.Phoenix.Socket module to help authenticate channels.
 
 ```elixir
 defmodule MyApp.UsersChannel do
   use Phoenix.Channel
-  use Guardian.Channel
+  import Guardian.Phoenix.Socket
 
-  def join(_room, %{ claims: claims, resource: resource }, socket) do
-    { :ok, %{ message: "Joined" }, socket }
+  def join(_room, %{"guardian_token" => token}, socket) do
+    case sign_in(socket, token) do
+      {:ok, authed_socket, _guardian_params} ->
+        {:ok, %{ message: "Joined" }, authed_socket}
+      {:error, reason} ->
+        # handle error
+    end
   end
 
   def join(room, _, socket) do
@@ -457,7 +533,7 @@ defmodule MyApp.UsersChannel do
   end
 
   def handle_in("ping", _payload, socket) do
-    user = Guardian.Channel.current_resource(socket)
+    user = current_resource(socket)
     broadcast socket, "pong", %{ message: "pong", from: user.email }
     { :noreply, socket }
   end

--- a/lib/guardian/channel.ex
+++ b/lib/guardian/channel.ex
@@ -9,17 +9,17 @@ defmodule Guardian.Channel do
         use Guardian.Channel
 
         def join(_room, %{ claims: claims, resource: resource }, socket) do
-          { :ok, %{ message: "Joined" }, socket }
+          {:ok, %{ message: "Joined" }, socket}
         end
 
         def join(room, _, socket) do
-          { :error,  :authentication_required }
+          {:error,  :authentication_required}
         end
 
         def handle_in("ping", _payload, socket) do
           user = Guardian.Channel.current_resource(socket)
-          broadcast socket, "pong", %{ message: "pong", from: user.email }
-          { :noreply, socket }
+          broadcast(socket, "pong", %{message: "pong", from: user.email})
+          {:noreply, socket}
         end
       end
 
@@ -32,48 +32,28 @@ defmodule Guardian.Channel do
 
       let guardianToken = jQuery('meta[name="guardian_token"]').attr('content')
       let chan = socket.chan("pings", { guardian_token: guardianToken })
+
+  Consider using Guardian.Phoenix.Socket helpers
+  directly and authenticating the connection rather than the channel.
   """
   defmacro __using__(opts) do
     opts = Enum.into(opts, %{})
     key = Map.get(opts, :key, :default)
 
     quote do
+      import Guardian.Phoenix.Socket
+
       def join(room, auth = %{ "guardian_token" => jwt }, socket) do
-        handle_guardian_join(room, jwt, %{ }, socket)
-      end
-
-      def handle_guardian_auth_failure(reason) do
-        { :error, %{ error: reason } }
-      end
-
-      defp handle_guardian_join(room, jwt, params, socket) do
-        case Guardian.decode_and_verify(jwt, params) do
-          { :ok, claims } ->
-            case Guardian.serializer.from_token(Map.get(claims, "sub")) do
-              { :ok, resource } ->
-                authed_socket = socket
-                |> assign(Guardian.Keys.claims_key(unquote(key)), claims)
-                |> assign(Guardian.Keys.resource_key(unquote(key)), resource)
-                join(
-                  room,
-                  %{ claims: claims, resource: resource },
-                  authed_socket
-                )
-              { :error, reason } -> handle_guardian_auth_failure(reason)
-            end
-          { :error, reason } -> handle_guardian_auth_failure(reason)
+        case sign_in(socket, jwt, params, key: key) do
+          {:ok, authed_socket, guardian_params} ->
+            join(room, Map.merge(params, guardian_params), authed_socket)
+          {:error, reason} -> handle_guardian_auth_failure(reason)
         end
       end
 
+      def handle_guardian_auth_failure(reason), do: {:error, %{ error: reason}}
+
       defoverridable [handle_guardian_auth_failure: 1]
     end
-  end
-
-  def claims(socket, key \\ :default) do
-    socket.assigns[Guardian.Keys.claims_key(key)]
-  end
-
-  def current_resource(socket, key \\ :default) do
-    socket.assigns[Guardian.Keys.resource_key(key)]
   end
 end

--- a/lib/guardian/channel.ex
+++ b/lib/guardian/channel.ex
@@ -43,7 +43,7 @@ defmodule Guardian.Channel do
     quote do
       import Guardian.Phoenix.Socket
 
-      def join(room, auth = %{ "guardian_token" => jwt }, socket) do
+      def join(room, auth = %{"guardian_token" => jwt}, socket) do
         case sign_in(socket, jwt, params, key: key) do
           {:ok, authed_socket, guardian_params} ->
             join(room, Map.merge(params, guardian_params), authed_socket)
@@ -51,7 +51,7 @@ defmodule Guardian.Channel do
         end
       end
 
-      def handle_guardian_auth_failure(reason), do: {:error, %{ error: reason}}
+      def handle_guardian_auth_failure(reason), do: {:error, %{error: reason}}
 
       defoverridable [handle_guardian_auth_failure: 1]
     end

--- a/lib/guardian/phoenix/socket.ex
+++ b/lib/guardian/phoenix/socket.ex
@@ -1,0 +1,137 @@
+defmodule Guardian.Phoenix.Socket do
+  @moduledoc """
+  Provides functions for managing authentication with sockets.
+  Usually you'd use this on the Socket to authenticate on connection on the `connect` function.
+
+  There are two main ways to use this module.
+
+  1. use Guardian.Phoenix.Socket
+  2. import Guardian.Phoenix.Socket
+
+  You use this function when you want to automatically sign in a socket on `connect`.
+  The case where authentication information is not provided is not handled so that you can handle it yourself.
+
+  ```elixir
+  defmodule MyApp.UserSocket do
+    use Phoenix.Socket
+    use Guardian.Phoenix.Socket
+
+    # This function will be called when there was no authentication information
+    def connect(_params,socket) do
+      :error
+    end
+  end
+  ```
+
+  If you want more control over the authentication of the connection, then you shoule `import Guardian.Phoenix.Socket` and use the `sign_in` function to authenticate.
+
+  defmodule MyApp.UserSocket do
+    use Phoenix.Socket
+    import Guardian.Phoenix.Socket
+
+    def connect(%{"guardian_token" => jwt } = params, socket) do
+      case sign_in(socket, jwt) do
+        {:ok, authed_socket, guardian_params} ->
+          {:ok, authed_socket}
+        _ -> :error
+      end
+    end
+  end
+
+  If you want to authenticate on the join of a channel, you can import this module and use the sign_in function as normal.
+  """
+  defmacro __using__(opts) do
+    opts = Enum.into(opts, %{})
+    key = Map.get(opts, :key, :default)
+
+    quote do
+      import Guardian.Phoenix.Socket
+
+      def connect(%{ "guardian_token" => jwt } = params, socket) do
+        case sign_in(socket, jwt, params, key: unquote(key)) do
+          {:ok, authed_socket, _guardian_params} -> {:ok, authed_socket}
+          _ -> :error
+        end
+      end
+    end
+  end
+
+  def claims(socket, key \\ :default), do: current_claims(socket, key) # deprecated in 1.0
+
+  @doc """
+  Fetches the `claims` map that was encoded into the token.
+  """
+  def current_claims(socket, key \\ :default), do: socket.assigns[Guardian.Keys.claims_key(key)]
+
+  @doc """
+  Fetches the JWT that was provided for the initial authentication. This is provided as an encoded string.
+  """
+  def current_token(socket, key \\ :default), do: socket.assigns[Guardian.Keys.jwt_key(key)]
+
+  @doc """
+  Loads the resource from the serializer.
+  The resource is not cached onto the socket so using this function will load a fresh version of the resource each time it's called.
+  """
+  def current_resource(socket, key \\ :default) do
+    case current_claims(socket, key) do
+      nil -> nil
+      claims ->
+        case Guardian.serializer.from_token(claims["sub"]) do
+          {:ok, resource} -> resource
+          _ -> nil
+        end
+    end
+  end
+
+  @doc """
+  Boolean if the token is present or not to indicate an authenticated socket
+  """
+  def authenticated?(socket, key \\ :default) do
+    socket
+    |> current_token(key)
+    |> is_binary
+  end
+
+  def sign_in(_socket, nil), do: {:error, :no_token}
+  def sign_in(socket, jwt), do: sign_in(socket, jwt, %{})
+
+  @doc """
+  Sign into a socket. Takes a JWT and verifies it. If successful it caches the JWT and decoded claims onto the socket for future use.
+  """
+  def sign_in(socket, jwt, params, opts \\ []) do
+    key = Keyword.get(opts, :key, :default)
+
+    case Guardian.decode_and_verify(jwt, params) do
+      {:ok, claims} ->
+        case Guardian.serializer.from_token(Map.get(claims, "sub")) do
+          {:ok, resource} ->
+            authed_socket = socket
+            |> Phoenix.Socket.assign(Guardian.Keys.claims_key(key), claims)
+            |> Phoenix.Socket.assign(Guardian.Keys.jwt_key(key), jwt)
+            {:ok, authed_socket, %{claims: claims, resource: resource, jwt: jwt}}
+          error -> error
+        end
+      error -> error
+    end
+  end
+
+  @doc """
+  Signout of the socket and also revoke the token. Using with GuardianDB this will render the token useless for future requests.
+  """
+  def sign_out!(socket, key \\ :default) do
+    jwt = current_token(socket)
+    claims = current_claims(socket)
+    Guardian.revoke!(jwt, claims)
+    sign_out(socket, key)
+  end
+
+  @doc """
+  Sign out of the socket but do not revoke. The token will still be valid for future requests.
+  """
+  def sign_out(socket, key \\ :default) do
+    socket
+    |> Phoenix.Socket.assign(Guardian.Keys.claims_key(key), nil)
+    |> Phoenix.Socket.assign(Guardian.Keys.resource_key(key), nil)
+    |> Phoenix.Socket.assign(Guardian.Keys.jwt_key(key), nil)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Guardian.Mixfile do
   use Mix.Project
 
-  @version "0.9.1"
+  @version "0.10.0"
   @url "https://github.com/ueberauth/guardian"
   @maintainers ["Daniel Neighman", "Sonny Scroggin", "Sean Callan"]
 

--- a/test/guardian/permissions_test.exs
+++ b/test/guardian/permissions_test.exs
@@ -43,7 +43,7 @@ defmodule Guardian.PermissionsTest do
   end
 
   test "when using max permissions all permissions are available" do
-    epxected_default = [:delete, :read, :update, :write]
+    expected_default = [:delete, :read, :update, :write]
     expected_other = [:other_delete, :other_read, :other_update, :other_write]
 
     found_default = Permissions.to_list(Permissions.max)
@@ -68,7 +68,7 @@ defmodule Guardian.PermissionsTest do
   test "fetches a list from a value" do
     ex_default = [:read, :write, :update]
     ex_other = [:other_read, :other_write, :other_update]
-    assert Enum.sort(Permissions.to_list(7)) == Enum.sort(ex_deafult)
+    assert Enum.sort(Permissions.to_list(7)) == Enum.sort(ex_default)
     assert Enum.sort(Permissions.to_list(7, :other)) == Enum.sort(ex_other)
   end
 

--- a/test/guardian/phoenix/socket_test.exs
+++ b/test/guardian/phoenix/socket_test.exs
@@ -1,0 +1,102 @@
+defmodule Guardian.Phoenix.SocketTest do
+  use ExUnit.Case, async: true
+
+  alias Guardian.Phoenix.Socket, as: GuardianSocket
+
+  defmodule TestSocket do
+    defstruct assigns: %{}
+  end
+
+  setup do
+    claims = %{
+      "aud" => "User:1",
+      "typ" => "token",
+      "exp" => Guardian.Utils.timestamp + 100_00,
+      "iat" => Guardian.Utils.timestamp,
+      "iss" => "MyApp",
+      "sub" => "User:1",
+      "something_else" => "foo"}
+
+    config = Application.get_env(:guardian, Guardian)
+    algo = hd(Keyword.get(config, :allowed_algos))
+    secret = Keyword.get(config, :secret_key)
+
+    jose_jws = %{"alg" => algo}
+    jose_jwk = %{"kty" => "oct", "k" => :base64url.encode(secret)}
+
+    { _, jwt } = JOSE.JWT.sign(jose_jwk, jose_jws, claims) |> JOSE.JWS.compact
+
+    { :ok, %{
+        socket: %TestSocket{},
+        claims: claims,
+        jwt: jwt,
+        jose_jws: jose_jws,
+        jose_jwk: jose_jwk
+      }
+    }
+  end
+
+  test "current_claims from socket", %{socket: socket} do
+    key = Guardian.Keys.claims_key
+    assigns = %{key => %{"the" => "claims"}}
+    socket = Map.put(socket, :assigns, assigns)
+    assert GuardianSocket.current_claims(socket) == %{"the" => "claims"}
+  end
+
+  test "current_claims from socket in secret location", %{socket: socket} do
+    key = Guardian.Keys.claims_key(:secret)
+    assigns = %{key => %{"the" => "claims"}}
+    socket = Map.put(socket, :assigns, assigns)
+    assert GuardianSocket.current_claims(socket, :secret) == %{"the" => "claims"}
+  end
+
+  test "current_token from socket", %{socket: socket} do
+    key = Guardian.Keys.jwt_key
+    assigns = %{key => "THE JWT"}
+    socket = Map.put(socket, :assigns, assigns)
+    assert GuardianSocket.current_token(socket) == "THE JWT"
+  end
+
+  test "current_token from socket secret location", %{socket: socket} do
+    key = Guardian.Keys.jwt_key(:secret)
+    assigns = %{key => "THE JWT"}
+    socket = Map.put(socket, :assigns, assigns)
+    assert GuardianSocket.current_token(socket, :secret) == "THE JWT"
+  end
+
+  test "fetches the serialized sub from the token for current_resource", %{socket: socket, claims: claims} do
+    key = Guardian.Keys.claims_key
+    assigns = %{key => claims}
+    socket = Map.put(socket, :assigns, assigns)
+
+    assert GuardianSocket.current_resource(socket) == claims["sub"]
+  end
+
+  test "does not have a current resource when there is no one logged in", %{socket: socket} do
+    assert GuardianSocket.current_resource(socket) == nil
+  end
+
+  test "is authenticated if there is a token present", %{socket: socket} do
+    assert GuardianSocket.authenticated?(socket) == false
+
+    key = Guardian.Keys.jwt_key
+    assigns = %{key => "THE JWT"}
+    socket = Map.put(socket, :assigns, assigns)
+
+    assert GuardianSocket.authenticated?(socket) == true
+  end
+
+  test "is authenticated if there is a token present in the secret location", %{socket: socket} do
+    assert GuardianSocket.authenticated?(socket, :secret) == false
+
+    key = Guardian.Keys.jwt_key(:secret)
+    assigns = %{key => "THE JWT"}
+    socket = Map.put(socket, :assigns, assigns)
+
+    assert GuardianSocket.authenticated?(socket, :secret) == true
+  end
+
+  test "sign in with a nil JWT", %{socket: socket} do
+    assert GuardianSocket.sign_in(socket, nil) == {:error, :no_token}
+  end
+end

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -85,7 +85,7 @@ defmodule GuardianTest do
   end
 
   test "it is invalid if the typ is incorrect", context do
-    resposne = Guardian.decode_and_verify(
+    response = Guardian.decode_and_verify(
       context.jwt,
       %{typ: "something_else"}
     )


### PR DESCRIPTION
Provides better helpers around phoenix sockets so we can authenticate on connect etc. Refactors the channel stuff. I think the channel module should be deprecated. 

Can I get a hell yeah?!