### PR TITLE
Bump Elixir dependency to 1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Guardian.Mixfile do
       name: "Guardian",
       app: :guardian,
       version: @version,
-      elixir: "~> 1.1",
+      elixir: "~> 1.2",
       package: package,
       source_url: @url,
       build_embedded: Mix.env == :prod,

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -49,29 +49,33 @@ defmodule GuardianTest do
     assert Guardian.issuer == "MyApp"
   end
 
-  test "it verifies the jwt", context do
+  test "decode_and_verify/1 verifies the jwt", context do
     assert Guardian.decode_and_verify(context.jwt) == { :ok, context.claims }
   end
 
-  test "verifies the issuer", context do
+  test "decode_and_verify/1 verifies the issuer", context do
     assert Guardian.decode_and_verify(context.jwt) == { :ok, context.claims }
   end
 
-  test "fails if the issuer is not correct", context do
+  test "decode_and_verify/1 fails if the issuer is not correct", context do
     claims = %{typ: "token", exp: Guardian.Utils.timestamp + 100_00, iat: Guardian.Utils.timestamp, iss: "not the issuer", sub: "User:1"}
     { _, jwt } = JOSE.JWT.sign(context.jose_jwk, context.jose_jws, claims) |> JOSE.JWS.compact
 
     assert Guardian.decode_and_verify(jwt) == { :error, :invalid_issuer }
   end
 
-  test "fails if the expiry has passed", context do
+  test "decode_and_verify/1 fails if the expiry has passed", context do
     claims = Map.put(context.claims, "exp", Guardian.Utils.timestamp - 10)
     { _, jwt } = JOSE.JWT.sign(context.jose_jwk, context.jose_jws, claims) |> JOSE.JWS.compact
 
     assert Guardian.decode_and_verify(jwt) == { :error, :token_expired }
   end
 
-  test "it is invalid if the typ is incorrect", context do
+  test "decode_and_verify/2 verifies if the expected_claims are correct", context do
+    assert Guardian.decode_and_verify(context.jwt, %{ typ: context.claims["typ"]})== { :ok, context.claims }
+  end
+
+  test "decode_and_verify/2 fails if the expected claims are not matched", context do
     assert Guardian.decode_and_verify(context.jwt, %{ typ: "something_else"}) == { :error, :invalid_type }
   end
 


### PR DESCRIPTION
This pull request bumps the elixir dependency to 1.2 so we can refactor nested case statements to use the new `with` syntax.

I do have a couple of questions:

1. `decode_and_verify/2` originally called `stringify_keys` twice in the following code:

  ```elixir
  def decode_and_verify(jwt, params) do
    params = stringify_keys(params)
    if verify_issuer?, do: params = Map.put_new(params, "iss", issuer)
    params = stringify_keys(params)

    # Rest of method ommitted
  end
  ```
  The second call to `stringify_keys` seemed to be redundant since the key that's being inserted is already a string. I removed the second `stringify_keys` call when I extracted the `build_expected_claims` function, but I was wondering if there is a reason that I shouldn't have removed it.
2. I also saw that there was a `try`/`rescue` block in `decode_and_verify/2`. What is the purpose of this and can it be removed?