### PR TITLE
raise error on missing units; add years to TTL

### DIFF
--- a/lib/guardian/claims.ex
+++ b/lib/guardian/claims.ex
@@ -82,6 +82,9 @@ defmodule Guardian.Claims do
       { iat, { hours, :hour } } -> Map.put(claims, "exp", iat + hours * 60 * 60)
       { iat, { days, :days } } -> Map.put(claims, "exp", iat + days * 24 * 60 * 60)
       { iat, { days, :day } } -> Map.put(claims, "exp", iat + days * 24 * 60 * 60)
+      { iat, { years, :years } } -> Map.put(claims, "exp", iat + years * 365 * 24 * 60 * 60)
+      { iat, { years, :year } } -> Map.put(claims, "exp", iat + years * 365 * 24 * 60 * 60)
+      { iat, { _, units } } -> raise "Unknown Units: #{units}"
       _ -> claims
     end
   end

--- a/test/guardian/claims_test.exs
+++ b/test/guardian/claims_test.exs
@@ -65,7 +65,6 @@ defmodule Guardian.ClaimsTest do
     assert Guardian.Claims.iat(claims, 15) == %{ "iat" => 15 }
   end
 
-
   test "ttl with nothing" do
     claims = %{ }
     the_claims = Guardian.Claims.ttl(claims)
@@ -76,6 +75,18 @@ defmodule Guardian.ClaimsTest do
   test "ttl with extisting iat" do
     claims = %{ "iat" => 10 }
     assert Guardian.Claims.ttl(claims) == %{ "iat" => 10, "exp" => 10 + 24 * 60 * 60 }
+  end
+
+  test "ttl with extisting iat & in minutes" do
+    claims = %{ "iat" => 10 }
+    assert Guardian.Claims.ttl(claims, { 10, :minutes }) == %{ "iat" => 10, "exp" => 10 + 10 * 60 }
+  end
+
+  test "ttl with extisting iat & in unknown units" do
+    claims = %{ "iat" => 10 }
+    assert_raise RuntimeError, "Unknown Units: decade", fn ->
+      Guardian.Claims.ttl(claims, { 1, :decade })
+    end
   end
 
   test "encodes permissions into the claims" do


### PR DESCRIPTION
I set a ttl to { 10, :years }, and was surprised the exp was not being set correctly. This adds years but also raises and error on unknown units.