### PR TITLE
Fix Guardian.Plug.ErrorHandler

### DIFF
--- a/lib/guardian/plug/error_handler.ex
+++ b/lib/guardian/plug/error_handler.ex
@@ -40,7 +40,7 @@ defmodule Guardian.Plug.ErrorHandler do
 
   defp accept_type(conn) do
     accept = conn
-    |> get_req_header(:accept)
+    |> get_req_header("accept")
     |> List.wrap
     |> hd
 


### PR DESCRIPTION
- As of Plug v1.1.0 the Plug.Conn.get_req_header/2 function has a guard clause that checks is_binary on the second argument(key), which fails in the case of passing an atom. After this correction it works like a charm.