### PR TITLE
Bumped JOSE version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Guardian.Mixfile do
   end
 
   defp deps do
-    [{:jose, "~> 1.4"},
+    [{:jose, "~> 1.6"},
      {:poison, "~> 1.5"},
      {:plug, "~> 1.0"},
      {:ex_doc, "~> 0.10", only: :docs},


### PR DESCRIPTION
Version 1.6.0 of erlang-jose adds the ability of using libsodium and SHA-3 (keccack) algorithms. This improves speed a lot. Reference link is [here](https://github.com/potatosalad/erlang-jose#curve25519-and-curve448-support).

Perhaps we should also include a guide on the benefits and disadvantages of using this faster encryption library. JOSE will auto detect the dependencies if they are present. A better explanation than mine is [here](https://github.com/bryanjos/joken/pull/113) from Andrew himself (complete with graphics and all!). A nice read :D