### PR TITLE
Fix Guardian.Plug.EnsureAuthenticated so it uses default ErrorHandler

### DIFF
--- a/test/guardian/plug/ensure_authenticated_test.exs
+++ b/test/guardian/plug/ensure_authenticated_test.exs
@@ -12,74 +12,104 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
     end
   end
 
-  @expected_failure TestHandler
-  @failure %{ handler: {@expected_failure, :unauthenticated}}
+  test "init/1 sets the handler option to the module that's passed in" do
+    %{handler: handler_opts} = EnsureAuthenticated.init(handler: TestHandler)
+
+    assert handler_opts == {TestHandler, :unauthenticated}
+  end
+
+  test "init/1 sets the handler option to the value of on_failure" do
+    %{handler: handler_opts} = EnsureAuthenticated.init(
+      on_failure: {TestHandler, :custom_failure_method}
+    )
+
+    assert handler_opts == {TestHandler, :custom_failure_method}
+  end
+
+  test "init/1 defaults the handler option to Guardian.Plug.ErrorHandler" do
+    %{handler: handler_opts} = EnsureAuthenticated.init %{}
+
+    assert handler_opts == {Guardian.Plug.ErrorHandler, :unauthenticated}
+  end
+
+  test "init/1 with default options" do
+    options = EnsureAuthenticated.init %{}
+
+    assert options == %{
+      claims: %{},
+      handler: {Guardian.Plug.ErrorHandler, :unauthenticated},
+      key: :default
+    }
+  end
+
+  test "init/1 uses all opts as claims except :on_failure, :key and :handler" do
+    %{claims: claims} = EnsureAuthenticated.init(
+      on_failure: {TestHandler, :some_method},
+      key: :super_secret,
+      handler: TestHandler,
+      foo: "bar",
+      another: "option"
+    )
+
+    assert claims == %{"foo" => "bar", "another" => "option"}
+  end
 
   test "it validates claims and calls through if the claims are ok" do
     claims = %{ "aud" => "token", "sub" => "user1" }
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
-    opts = EnsureAuthenticated.init(handler: @expected_failure, aud: "token")
+    opts = EnsureAuthenticated.init(handler: TestHandler, aud: "token")
     ensured_conn = EnsureAuthenticated.call(conn, opts)
-    assert ensured_conn.assigns[:guardian_spec] == nil
+    refute must_authenticate?(ensured_conn)
   end
 
   test "it validates claims and fails if the claims do not match" do
     claims = %{ "aud" => "oauth", "sub" => "user1" }
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({:ok, claims})
-    opts = EnsureAuthenticated.init(handler: @expected_failure, aud: "token")
+    opts = EnsureAuthenticated.init(handler: TestHandler, aud: "token")
     ensured_conn = EnsureAuthenticated.call(conn, opts)
-    assert ensured_conn.assigns[:guardian_spec] == :unauthenticated
+    assert must_authenticate?(ensured_conn)
   end
 
-  test "it does not call on failure with a session at the default location" do
+  test "doesn't call unauthenticated when there's a session with default key" do
     claims = %{ "aud" => "token", "sub" => "user1" }
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
-    ensured_conn = EnsureAuthenticated.call(conn, @failure)
-    assert ensured_conn.assigns[:guardian_spec] == nil
+    opts = EnsureAuthenticated.init(handler: TestHandler)
+    ensured_conn = EnsureAuthenticated.call(conn, opts)
+    refute must_authenticate?(ensured_conn)
   end
 
-  test "it does not call on failure with a session at the specific location" do
+  test "doesn't call unauthenticated when theres a session with specific key" do
     claims = %{ "aud" => "token", "sub" => "user1" }
     conn = :get
-           |> conn("/foo")
-           |> Guardian.Plug.set_claims({:ok, claims}, :secret)
-
-    ensured_conn = EnsureAuthenticated.call(
-      conn,
-      %{handler: {@expected_failure, :unauthenticated}, key: :secret}
-    )
-
-    assert ensured_conn.assigns[:guardian_spec] == nil
+            |> conn("/foo")
+            |> Guardian.Plug.set_claims({:ok, claims}, :secret)
+    opts = EnsureAuthenticated.init(handler: TestHandler, key: :secret)
+    ensured_conn = EnsureAuthenticated.call(conn, opts)
+    refute must_authenticate?(ensured_conn)
   end
 
-  test "it calls the handler unauthenticated with no session at default" do
+  test "calls handler's unauthenticated/2 with no session for default key" do
     conn = conn(:get, "/foo")
-    ensured_conn = EnsureAuthenticated.call(conn, @failure)
-    assert ensured_conn.assigns[:guardian_spec] == :unauthenticated
+    opts = EnsureAuthenticated.init(handler: TestHandler)
+    ensured_conn = EnsureAuthenticated.call(conn, opts)
+    assert must_authenticate?(ensured_conn)
   end
 
-  test "it calls on_failiure function with no session at the location" do
+  test "calls handler's unauthenticated/2 with no session for specific key" do
     conn = conn(:get, "/foo")
-    ensured_conn = EnsureAuthenticated.call(
-      conn,
-      %{
-        handler: {@expected_failure, :unauthenticated},
-        key: :secret
-      }
-    )
-
-    assert ensured_conn.assigns[:guardian_spec] == :unauthenticated
+    opts = EnsureAuthenticated.init(handler: TestHandler, key: :secret)
+    ensured_conn = EnsureAuthenticated.call(conn, opts)
+    assert must_authenticate?(ensured_conn)
   end
 
   test "it halts the connection" do
     conn = conn(:get, "/foo")
-    ensured_conn = EnsureAuthenticated.call(
-      conn,
-      %{
-        handler: {@expected_failure, :unauthenticated},
-        key: :secret
-      }
-    )
+    opts = EnsureAuthenticated.init(handler: TestHandler, key: :secret)
+    ensured_conn = EnsureAuthenticated.call(conn, opts)
     assert ensured_conn.halted
+  end
+
+  defp must_authenticate?(conn) do
+    conn.assigns[:guardian_spec] == :unauthenticated
   end
 end


### PR DESCRIPTION
According to the documentation, the `Guardian.Plug.EnsureAuthenticated` plug's `:handler` option should default to `Guardian.Plug.EnsureAuthenticated`.  If you currently try to use the plug without the `:handler` option, it raises an error saying "Requires a handler module to be passed".

In addition to updating the default value I also:
* Removed references to old on_failure method
* Refactored tests so options passed into `EnsureAuthenticated.call` are generated by `EnsureAuthenticated.init` method instead of being hard coded at the top of the file.
* Added tests for the `init` method

The only thing that I see as a potential issue is when you run the tests, one of Guardian' deprecation warnings is printed out. I wrote a test to ensure the `:on_failure` argument continues to work even though it's deprecated. Any tips on how to not have the deprecation warning go into the test output would be greatly appreciated.