### PR TITLE
Fixed error in ErrorHandler when accept header isn’t set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Master (Unreleased)
+
+* Fix error in Guardian.Plug.ErrorHandler when Accept header is unset.
+
 # v 0.10.0
 
 * Add a Guardian.Phoenix.Socket module and refactor Guardian.Channel

--- a/lib/guardian/plug/error_handler.ex
+++ b/lib/guardian/plug/error_handler.ex
@@ -9,11 +9,11 @@ defmodule Guardian.Plug.ErrorHandler do
   import Plug.Conn
 
   def unauthenticated(conn, _params) do
-    respond(conn, accept_type(conn), 401, "Unauthenticated")
+    respond(conn, response_type(conn), 401, "Unauthenticated")
   end
 
   def unauthorized(conn, _params) do
-    respond(conn, accept_type(conn), 403, "Unauthorized")
+    respond(conn, response_type(conn), 403, "Unauthorized")
   end
 
   defp respond(conn, :json, status, msg) do
@@ -42,15 +42,19 @@ defmodule Guardian.Plug.ErrorHandler do
     end
   end
 
-  defp accept_type(conn) do
-    accept = conn
-    |> get_req_header("accept")
-    |> List.wrap
-    |> hd
-
+  defp response_type(conn) do
+    accept = accept_header(conn)
     cond do
       Regex.match?(~r/json/, accept) -> :json
       true -> :html
     end
+  end
+
+  defp accept_header(conn)  do
+    value = conn
+      |> get_req_header("accept")
+      |> List.first
+
+    value || ""
   end
 end

--- a/test/guardian/plug/error_handler_test.exs
+++ b/test/guardian/plug/error_handler_test.exs
@@ -1,0 +1,100 @@
+defmodule Guardian.Plug.ErrorHandlerTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Guardian.Plug.ErrorHandler
+
+  setup do
+    conn = conn(:get, "/foo")
+    {:ok, %{conn: conn}}
+  end
+
+  test "unauthenticated/2 sends a 401 response when text/html", %{conn: conn} do
+    conn = put_req_header(conn, "accept", "text/html")
+
+    {status, headers, body} =
+      conn
+      |> ErrorHandler.unauthenticated(%{})
+      |> sent_resp
+
+    assert status == 401
+    assert content_type(headers) == "text/plain"
+    assert body == "Unauthenticated"
+  end
+
+  test "unauthenticated/2 sends a 401 response when json", %{conn: conn} do
+    conn = put_req_header(conn, "accept", "application/json")
+
+    {status, headers, body} =
+      conn
+      |> ErrorHandler.unauthenticated(%{})
+      |> sent_resp
+
+    assert status == 401
+    assert content_type(headers) == "application/json"
+    assert body ==  Poison.encode!(%{errors: ["Unauthenticated"]})
+  end
+
+  test "unauthenticated/2 when no accept header", %{conn: conn} do
+    {status, headers, body} =
+      conn
+      |> ErrorHandler.unauthenticated(%{})
+      |> sent_resp
+
+    assert status == 401
+    assert content_type(headers) == "text/plain"
+    assert body ==  "Unauthenticated"
+  end
+
+  test "unauthorized/2 sends a 403 response when text/html", %{conn: conn} do
+    conn = put_req_header(conn, "accept", "text/html")
+
+    {status, headers, body} =
+      conn
+      |> ErrorHandler.unauthorized(%{})
+      |> sent_resp
+
+    assert status == 403
+    assert content_type(headers) == "text/plain"
+    assert body == "Unauthorized"
+  end
+
+  test "unauthorized/2 sends a 403 response when json", %{conn: conn} do
+    conn = put_req_header(conn, "accept", "application/json")
+
+    {status, headers, body} =
+      conn
+      |> ErrorHandler.unauthorized(%{})
+      |> sent_resp
+
+    assert status == 403
+    assert content_type(headers) == "application/json"
+    assert body ==  Poison.encode!(%{errors: ["Unauthorized"]})
+  end
+
+  test "unauthorized/2 sends 403 resp when no accept header", %{conn: conn} do
+    {status, headers, body} =
+      conn
+      |> ErrorHandler.unauthorized(%{})
+      |> sent_resp
+
+    assert status == 403
+    assert content_type(headers) == "text/plain"
+    assert body == "Unauthorized"
+  end
+
+  defp content_type(headers) do
+    {:ok, type, subtype, _params} =
+      headers
+        |> header_value("content-type")
+        |> Plug.Conn.Utils.content_type
+    "#{type}/#{subtype}"
+  end
+
+  defp header_value(headers, key) do
+    headers
+    |> Enum.filter(fn({k, _}) -> k == key end)
+    |> Enum.map(fn({_, v}) -> v end)
+    |> List.first
+  end
+end


### PR DESCRIPTION
The current version of `Guardian.Plug.ErrorHandler` raises the following error when no `Accept` header is set.

```
** (ArgumentError) argument error
stacktrace:
  :erlang.hd([])
  (guardian) lib/guardian/plug/error_handler.ex:49: Guardian.Plug.ErrorHandler.accept_type/1
  (guardian) lib/guardian/plug/error_handler.ex:12: Guardian.Plug.ErrorHandler.unauthenticated/2
```

I was running into this problem when writing controller tests and I hadn't explicitly set the `Accept` header. This change also adds test coverage to Plug.Guardian.ErrorHandler module.

The build is failing because of the 80 char line length restriction added in #97. Would you be up to changing that restriction to 120 characters so we can maintain more detailed test descriptions and pass in parameters from the setup block? It's kind of a bummer you can't just say 120 characters for only test descriptions, but it doesn't look like dogma allows that.