### PR TITLE
Adding ensure_not_authenticated plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Master (Unreleased)
 
 * Fix error in Guardian.Plug.ErrorHandler when Accept header is unset.
+* Adding Guardian.Plug.EnsureNotAuthenticated to validates that user isn't logged
 
 # v 0.10.0
 

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -1,6 +1,6 @@
 defmodule Guardian.Plug.EnsureNotAuthenticated do
   @moduledoc """
-  This plug ensures that a valid JWT was provided and has been
+  This plug ensures that a invalid JWT was provided and has been
   verified on the request.
 
   If one is not found, the `authenticated/2` function is invoked with the
@@ -32,7 +32,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
       handler: handler,
       key: Map.get(opts, :key, :default),
       claims: Guardian.Utils.stringify_keys(claims_to_check)
-    }
+  }
   end
 
   @doc false
@@ -40,8 +40,8 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
     key = Map.get(opts, :key, :default)
 
     case Guardian.Plug.claims(conn, key) do
-      { :ok, claims } -> conn |> check_claims(opts, claims)
-      { :error, reason } -> conn
+      {:ok, claims} -> conn |> check_claims(opts, claims)
+      {:error, reason} -> conn
       _ -> conn
     end
   end
@@ -54,16 +54,16 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
     apply(
       mod,
       meth,
-      [the_connection, Map.merge(the_connection.params, %{ reason: reason })]
+      [the_connection, Map.merge(the_connection.params, %{reason: reason})]
     )
   end
 
-  defp check_claims(conn, opts = %{ claims: claims_to_check }, claims) do
+  defp check_claims(conn, opts = %{claims: claims_to_check}, claims) do
     claims_match = claims_to_check
                    |> Map.keys
                    |> Enum.all?(&(claims_to_check[&1] == claims[&1]))
     if claims_match do
-      handle_error(conn, { :error, :claims_match }, opts)
+      handle_error(conn, {:error, :claims_match}, opts)
     else
       conn
     end

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -9,12 +9,12 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
   ## Example
 
       # Will call the authenticated/2 function on your handler
-      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule
+      plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule
 
       # look in the :secret location.  You can also do simple claim checks:
-      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule, key: :secret
+      plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule, key: :secret
 
-      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule, aud: "token"
+      plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule, aud: "token"
 
   If the handler option is not passed, `Guardian.Plug.ErrorHandler` will provide
   the default behavior.

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -3,7 +3,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
   This plug ensures that a invalid JWT was provided and has been
   verified on the request.
 
-  If one is not found, the `authenticated/2` function is invoked with the
+  If one is found, the `authenticated/2` function is invoked with the
   `Plug.Conn.t` object and its params.
 
   ## Example

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -27,12 +27,12 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
     opts = Enum.into(opts, %{})
     handler = build_handler_tuple(opts)
 
-    claims_to_check = Map.drop(opts, [:on_failure, :key, :handler])
+    claims_to_check = Map.drop(opts, [:key, :handler])
     %{
       handler: handler,
       key: Map.get(opts, :key, :default),
       claims: Guardian.Utils.stringify_keys(claims_to_check)
-  }
+    }
   end
 
   @doc false
@@ -72,13 +72,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
   defp build_handler_tuple(%{handler: mod}) do
     {mod, :authenticated}
   end
-  defp build_handler_tuple(%{on_failure: {mod, func}}) do
-    Logger.log(
-      :warn,
-      ":on_failure is deprecated. Use the :handler option instead"
-    )
-    {mod, func}
-  end
+
   defp build_handler_tuple(_) do
     {Guardian.Plug.ErrorHandler, :authenticated}
   end

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -3,12 +3,12 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
   This plug ensures that a invalid JWT was provided and has been
   verified on the request.
 
-  If one is found, the `authenticated/2` function is invoked with the
+  If one is found, the `already_authenticated/2` function is invoked with the
   `Plug.Conn.t` object and its params.
 
   ## Example
 
-      # Will call the authenticated/2 function on your handler
+      # Will call the already_authenticated/2 function on your handler
       plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule
 
       # look in the :secret location.  You can also do simple claim checks:
@@ -72,10 +72,10 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
   end
 
   defp build_handler_tuple(%{handler: mod}) do
-    {mod, :authenticated}
+    {mod, :already_authenticated}
   end
 
   defp build_handler_tuple(_) do
-    {Guardian.Plug.ErrorHandler, :authenticated}
+    {Guardian.Plug.ErrorHandler, :already_authenticated}
   end
 end

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -41,7 +41,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
 
     case Guardian.Plug.claims(conn, key) do
       {:ok, claims} -> conn |> check_claims(opts, claims)
-      {:error, reason} -> conn
+      {:error, _reason} -> conn
       _ -> conn
     end
   end

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -1,0 +1,85 @@
+defmodule Guardian.Plug.EnsureNotAuthenticated do
+  @moduledoc """
+  This plug ensures that a valid JWT was provided and has been
+  verified on the request.
+
+  If one is not found, the `authenticated/2` function is invoked with the
+  `Plug.Conn.t` object and its params.
+
+  ## Example
+
+      # Will call the authenticated/2 function on your handler
+      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule
+
+      # look in the :secret location.  You can also do simple claim checks:
+      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule, key: :secret
+
+      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule, aud: "token"
+
+  If the handler option is not passed, `Guardian.Plug.ErrorHandler` will provide
+  the default behavior.
+  """
+  require Logger
+  import Plug.Conn
+
+  @doc false
+  def init(opts) do
+    opts = Enum.into(opts, %{})
+    handler = build_handler_tuple(opts)
+
+    claims_to_check = Map.drop(opts, [:on_failure, :key, :handler])
+    %{
+      handler: handler,
+      key: Map.get(opts, :key, :default),
+      claims: Guardian.Utils.stringify_keys(claims_to_check)
+    }
+  end
+
+  @doc false
+  def call(conn, opts) do
+    key = Map.get(opts, :key, :default)
+
+    case Guardian.Plug.claims(conn, key) do
+      { :ok, claims } -> conn |> check_claims(opts, claims)
+      { :error, reason } -> conn
+      _ -> conn
+    end
+  end
+
+  @doc false
+  defp handle_error(conn, reason, opts) do
+    the_connection = conn |> assign(:guardian_failure, reason) |> halt
+
+    {mod, meth} = Map.get(opts, :handler)
+    apply(
+      mod,
+      meth,
+      [the_connection, Map.merge(the_connection.params, %{ reason: reason })]
+    )
+  end
+
+  defp check_claims(conn, opts = %{ claims: claims_to_check }, claims) do
+    claims_match = claims_to_check
+                   |> Map.keys
+                   |> Enum.all?(&(claims_to_check[&1] == claims[&1]))
+    if claims_match do
+      handle_error(conn, { :error, :claims_match }, opts)
+    else
+      conn
+    end
+  end
+
+  defp build_handler_tuple(%{handler: mod}) do
+    {mod, :authenticated}
+  end
+  defp build_handler_tuple(%{on_failure: {mod, func}}) do
+    Logger.log(
+      :warn,
+      ":on_failure is deprecated. Use the :handler option instead"
+    )
+    {mod, func}
+  end
+  defp build_handler_tuple(_) do
+    {Guardian.Plug.ErrorHandler, :authenticated}
+  end
+end

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -12,9 +12,11 @@ defmodule Guardian.Plug.EnsureNotAuthenticated do
       plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule
 
       # look in the :secret location.  You can also do simple claim checks:
-      plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule, key: :secret
+      plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule,
+                                                 key: :secret
 
-      plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule, aud: "token"
+      plug Guardian.Plug.EnsureNotAuthenticated, handler: SomeModule,
+                                                 aud: "token"
 
   If the handler option is not passed, `Guardian.Plug.ErrorHandler` will provide
   the default behavior.

--- a/lib/guardian/plug/error_handler.ex
+++ b/lib/guardian/plug/error_handler.ex
@@ -16,6 +16,10 @@ defmodule Guardian.Plug.ErrorHandler do
     respond(conn, response_type(conn), 403, "Unauthorized")
   end
 
+  def already_authenticated(conn, _params) do
+    conn |> halt
+  end
+
   defp respond(conn, :json, status, msg) do
     try do
       conn

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -1,0 +1,115 @@
+defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Guardian.Plug.EnsureNotAuthenticated
+
+  defmodule TestHandler do
+    def authenticated(conn, _) do
+      conn
+      |> Plug.Conn.assign(:guardian_spec, :authenticated)
+      |> Plug.Conn.send_resp(401, "Authenticated")
+    end
+  end
+
+  test "init/1 sets the handler option to the module that's passed in" do
+    %{handler: handler_opts} = EnsureNotAuthenticated.init(handler: TestHandler)
+
+    assert handler_opts == {TestHandler, :authenticated}
+  end
+
+  test "init/1 sets the handler option to the value of on_failure" do
+    %{handler: handler_opts} = EnsureNotAuthenticated.init(
+      on_failure: {TestHandler, :custom_failure_method}
+    )
+
+    assert handler_opts == {TestHandler, :custom_failure_method}
+  end
+
+  test "init/1 defaults the handler option to Guardian.Plug.ErrorHandler" do
+    %{handler: handler_opts} = EnsureNotAuthenticated.init %{}
+
+    assert handler_opts == {Guardian.Plug.ErrorHandler, :authenticated}
+  end
+
+  test "init/1 with default options" do
+    options = EnsureNotAuthenticated.init %{}
+
+    assert options == %{
+      claims: %{},
+      handler: {Guardian.Plug.ErrorHandler, :authenticated},
+      key: :default
+    }
+  end
+
+  test "init/1 uses all opts as claims except :on_failure, :key and :handler" do
+    %{claims: claims} = EnsureNotAuthenticated.init(
+      on_failure: {TestHandler, :some_method},
+      key: :super_secret,
+      handler: TestHandler,
+      foo: "bar",
+      another: "option"
+    )
+
+    assert claims == %{"foo" => "bar", "another" => "option"}
+  end
+
+  test "it validates claims and calls through if the claims are ok" do
+    claims = %{ "aud" => "token", "sub" => "user1" }
+    conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
+    opts = EnsureNotAuthenticated.init(handler: TestHandler, aud: "token")
+    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
+    assert must_authenticate?(ensured_conn)
+  end
+
+  test "it validates claims and fails if the claims do not match" do
+    claims = %{ "aud" => "oauth", "sub" => "user1" }
+    conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({:ok, claims})
+    opts = EnsureNotAuthenticated.init(handler: TestHandler, aud: "token")
+    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
+    refute must_authenticate?(ensured_conn)
+  end
+
+  test "doesn't call unauthenticated when there's a session with default key" do
+    claims = %{ "aud" => "token", "sub" => "user1" }
+    conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
+    opts = EnsureNotAuthenticated.init(handler: TestHandler)
+    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
+    assert must_authenticate?(ensured_conn)
+  end
+
+  test "doesn't call unauthenticated when theres a session with specific key" do
+    claims = %{ "aud" => "token", "sub" => "user1" }
+    conn = :get
+            |> conn("/foo")
+            |> Guardian.Plug.set_claims({:ok, claims}, :secret)
+    opts = EnsureNotAuthenticated.init(handler: TestHandler, key: :secret)
+    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
+    assert must_authenticate?(ensured_conn)
+  end
+
+  test "calls handler's unauthenticated/2 with no session for default key" do
+    conn = conn(:get, "/foo")
+    opts = EnsureNotAuthenticated.init(handler: TestHandler)
+    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
+    refute must_authenticate?(ensured_conn)
+  end
+
+  test "calls handler's unauthenticated/2 with no session for specific key" do
+    conn = conn(:get, "/foo")
+    opts = EnsureNotAuthenticated.init(handler: TestHandler, key: :secret)
+    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
+    refute must_authenticate?(ensured_conn)
+  end
+
+  test "it halts the connection" do
+    conn = conn(:get, "/foo")
+    opts = EnsureNotAuthenticated.init(handler: TestHandler, key: :secret)
+    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
+    refute ensured_conn.halted
+  end
+
+  defp must_authenticate?(conn) do
+    conn.assigns[:guardian_spec] == :authenticated
+  end
+end

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -39,7 +39,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
     opts = EnsureNotAuthenticated.init(handler: TestHandler, aud: "token")
     ensured_conn = EnsureNotAuthenticated.call(conn, opts)
-    assert must_authenticate?(ensured_conn)
+    refute already_authenticated?(ensured_conn)
   end
 
   test "it validates claims and fails if the claims do not match" do
@@ -47,7 +47,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({:ok, claims})
     opts = EnsureNotAuthenticated.init(handler: TestHandler, aud: "token")
     ensured_conn = EnsureNotAuthenticated.call(conn, opts)
-    refute must_authenticate?(ensured_conn)
+    assert already_authenticated?(ensured_conn)
   end
 
   test "doesn't call unauthenticated when there's a session with default key" do
@@ -55,7 +55,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
     opts = EnsureNotAuthenticated.init(handler: TestHandler)
     ensured_conn = EnsureNotAuthenticated.call(conn, opts)
-    assert must_authenticate?(ensured_conn)
+    refute already_authenticated?(ensured_conn)
   end
 
   test "doesn't call unauthenticated when theres a session with specific key" do
@@ -65,21 +65,21 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
             |> Guardian.Plug.set_claims({:ok, claims}, :secret)
     opts = EnsureNotAuthenticated.init(handler: TestHandler, key: :secret)
     ensured_conn = EnsureNotAuthenticated.call(conn, opts)
-    assert must_authenticate?(ensured_conn)
+    refute already_authenticated?(ensured_conn)
   end
 
   test "calls handler's unauthenticated/2 with no session for default key" do
     conn = conn(:get, "/foo")
     opts = EnsureNotAuthenticated.init(handler: TestHandler)
     ensured_conn = EnsureNotAuthenticated.call(conn, opts)
-    refute must_authenticate?(ensured_conn)
+    assert already_authenticated?(ensured_conn)
   end
 
   test "calls handler's unauthenticated/2 with no session for specific key" do
     conn = conn(:get, "/foo")
     opts = EnsureNotAuthenticated.init(handler: TestHandler, key: :secret)
     ensured_conn = EnsureNotAuthenticated.call(conn, opts)
-    refute must_authenticate?(ensured_conn)
+    assert already_authenticated?(ensured_conn)
   end
 
   test "it halts the connection" do
@@ -89,7 +89,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     refute ensured_conn.halted
   end
 
-  defp must_authenticate?(conn) do
-    conn.assigns[:guardian_spec] == :authenticated
+  defp already_authenticated?(conn) do
+    conn.assigns[:guardian_spec] != :authenticated
   end
 end

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -42,6 +42,14 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     assert already_authenticated?(ensured_conn)
   end
 
+  test "it validates claims and fails if the claims do match (without handler option)" do
+    claims = %{ "aud" => "token", "sub" => "user1" }
+    conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
+    opts = EnsureNotAuthenticated.init(aud: "token")
+    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
+    assert ensured_conn.halted
+  end
+
   test "it validates claims and calls through if the claims are not ok" do
     claims = %{ "aud" => "oauth", "sub" => "user1" }
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({:ok, claims})

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -5,7 +5,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
   alias Guardian.Plug.EnsureNotAuthenticated
 
   defmodule TestHandler do
-    def authenticated(conn, _) do
+    def already_authenticated(conn, _) do
       conn
       |> Plug.Conn.assign(:guardian_spec, :authenticated)
       |> Plug.Conn.send_resp(401, "Authenticated")
@@ -15,13 +15,13 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
   test "init/1 sets the handler option to the module that's passed in" do
     %{handler: handler_opts} = EnsureNotAuthenticated.init(handler: TestHandler)
 
-    assert handler_opts == {TestHandler, :authenticated}
+    assert handler_opts == {TestHandler, :already_authenticated}
   end
 
   test "init/1 defaults the handler option to Guardian.Plug.ErrorHandler" do
     %{handler: handler_opts} = EnsureNotAuthenticated.init %{}
 
-    assert handler_opts == {Guardian.Plug.ErrorHandler, :authenticated}
+    assert handler_opts == {Guardian.Plug.ErrorHandler, :already_authenticated}
   end
 
   test "init/1 with default options" do
@@ -29,7 +29,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
 
     assert options == %{
       claims: %{},
-      handler: {Guardian.Plug.ErrorHandler, :authenticated},
+      handler: {Guardian.Plug.ErrorHandler, :already_authenticated},
       key: :default
     }
   end

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -42,14 +42,6 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     assert already_authenticated?(ensured_conn)
   end
 
-  test "it validates claims and fails if the claims do match (without handler option)" do
-    claims = %{ "aud" => "token", "sub" => "user1" }
-    conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
-    opts = EnsureNotAuthenticated.init(aud: "token")
-    ensured_conn = EnsureNotAuthenticated.call(conn, opts)
-    assert ensured_conn.halted
-  end
-
   test "it validates claims and calls through if the claims are not ok" do
     claims = %{ "aud" => "oauth", "sub" => "user1" }
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({:ok, claims})

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -18,14 +18,6 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     assert handler_opts == {TestHandler, :authenticated}
   end
 
-  test "init/1 sets the handler option to the value of on_failure" do
-    %{handler: handler_opts} = EnsureNotAuthenticated.init(
-      on_failure: {TestHandler, :custom_failure_method}
-    )
-
-    assert handler_opts == {TestHandler, :custom_failure_method}
-  end
-
   test "init/1 defaults the handler option to Guardian.Plug.ErrorHandler" do
     %{handler: handler_opts} = EnsureNotAuthenticated.init %{}
 
@@ -40,18 +32,6 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
       handler: {Guardian.Plug.ErrorHandler, :authenticated},
       key: :default
     }
-  end
-
-  test "init/1 uses all opts as claims except :on_failure, :key and :handler" do
-    %{claims: claims} = EnsureNotAuthenticated.init(
-      on_failure: {TestHandler, :some_method},
-      key: :super_secret,
-      handler: TestHandler,
-      foo: "bar",
-      another: "option"
-    )
-
-    assert claims == %{"foo" => "bar", "another" => "option"}
   end
 
   test "it validates claims and calls through if the claims are ok" do

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -34,7 +34,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     }
   end
 
-  test "it validates claims and calls through if the claims are not ok" do
+  test "it validates claims and fails if the claims do match" do
     claims = %{ "aud" => "token", "sub" => "user1" }
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
     opts = EnsureNotAuthenticated.init(handler: TestHandler, aud: "token")
@@ -42,7 +42,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     assert already_authenticated?(ensured_conn)
   end
 
-  test "it validates claims and fails if the claims do match" do
+  test "it validates claims and calls through if the claims are not ok" do
     claims = %{ "aud" => "oauth", "sub" => "user1" }
     conn = :get |> conn("/foo") |> Guardian.Plug.set_claims({:ok, claims})
     opts = EnsureNotAuthenticated.init(handler: TestHandler, aud: "token")

--- a/test/guardian/plug/error_handler_test.exs
+++ b/test/guardian/plug/error_handler_test.exs
@@ -83,6 +83,12 @@ defmodule Guardian.Plug.ErrorHandlerTest do
     assert body == "Unauthorized"
   end
 
+  test "already_authenticated/2 halt the conn", %{conn: conn} do
+    conn = conn
+           |> ErrorHandler.already_authenticated(%{})
+    assert conn.halted
+  end
+
   defp content_type(headers) do
     {:ok, type, subtype, _params} =
       headers


### PR DESCRIPTION
Hi guys,
I come home early from my business trip, so I start the pull request today.

This pull request add a ensure_not_authenticate plug for the case of page that user needs to be  not authenticated like sign_up/sign_in pages.

#106 