### PR TITLE
Refactor Plug Tests

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -23,6 +23,30 @@ defmodule Guardian.TestHelper do
     |> Plug.Session.call(@signing_opts)
     |> Plug.Conn.fetch_session
   end
+
+  @doc """
+  Helper for running a plug.
+
+  Calls the plug module's `init/1` function with
+  no arguments and passes the results to `call/2`
+  as the second argument.
+  """
+  def run_plug(conn, plug_module) do
+    opts = apply(plug_module, :init, [])
+    apply(plug_module, :call, [conn, opts])
+  end
+
+  @doc """
+  Helper for running a plug.
+
+  Calls the plug module's `init/1` function with
+  the value of `plug_opts` and passes the results to
+  `call/2` as the second argument.
+  """
+  def run_plug(conn, plug_module, plug_opts) do
+    opts = apply(plug_module, :init, [plug_opts])
+    apply(plug_module, :call, [conn, opts])
+  end
 end
 
 ExUnit.start()


### PR DESCRIPTION
I'd love to get your feedback on this PR. When dogma was introduced, many of the plug tests were refactored to have lines like this:

```elixir
:get |> conn("/foo") |> Guardian.Plug.set_claims({ :ok, claims })
```
This takes a minute for me to figure out what's going on and distracts me from the core things that are happening in the test. This PR moves making that arbitrary GET request into the setup block, so each test is passed a connection that is already ready to go.

```elixir
setup do
  conn = conn(:get, "/foo")
  {:ok, %{conn: conn}}
end

test "validates claims and calls through if claims are ok", %{conn: conn} do
  # conn is already setup now...
end
```

The other thing that's repeated over and over is this:

```elixir
opts = EnsureAuthenticated.init(handler: TestHandler, aud: "token")
ensured_conn = EnsureAuthenticated.call(conn, opts)
```
This code is just boilerplate for running the plug. It will always run the `init` function with certain arguments, and then pass the generated options into the `call` function as the 2nd parameter. I figured this boilerplate doesn't add to the readability of the test, so I extracted it into a `run_plug` helper. This allows a whole test to be written like this:

``` elixir
test "validates claims and calls through if claims are ok", %{conn: conn} do
  claims = %{ "aud" => "token", "sub" => "user1" }
  
  ensured_conn =
    conn
    |> Guardian.Plug.set_claims({ :ok, claims })
    |> run_plug(EnsureAuthenticated, handler: TestHandler, aud: "token")
  
  refute must_authenticate?(ensured_conn)
end
```

I'd love to hear your feedback on these changes. Do you think it makes the tests easier to read, or does it hide too much? If you like it, I'd be happy to update the rest of the plug tests before you merge this PR.