### PR TITLE
Added Guardian.Plug.Backdoor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master (Unreleased)
 
+* Add Guardian.Plug.Backdoor for acceptance testing
+
 # v 0.10.1
 
 * Fix error in Guardian.Plug.ErrorHandler when Accept header is unset.

--- a/lib/guardian/plug/backdoor.ex
+++ b/lib/guardian/plug/backdoor.ex
@@ -1,0 +1,115 @@
+defmodule Guardian.Plug.Backdoor do
+  @moduledoc """
+  This plug allows you to bypass authentication in acceptance tests
+  by passing the token needed to load the current resource directly to your
+  serializer, via a query string parameter.
+
+  ## Installation
+
+  Add the following to your Phoenix router before any other Guardian plugs.
+
+  ```
+  if Mix.env == :test do
+    plug Guardian.Plug.Backdoor
+  end
+  ```
+
+  ***This plug is designed for acceptance testing scenarios and should
+  never be added in a production environment.***
+
+  ## Usage
+
+  Now that `Guardian.Plug.Backdoor` is installed, it's time to log in.
+  If you're using [Hound][hound], you can write the following code.
+
+  ```
+  navigate_to "/?as=User:5"
+  ```
+
+  If you aren't using [Hound][hound], a simple `GET /?as=User:5` request will
+  work.
+
+  When the `Guardian.Plug.Backdoor` plug runs, it passes along the value
+  of the `as` parameter directly to your application's Guardian serializer.
+
+  ```
+  defmodule MyGuardianSerializer do
+    @behaviour Guardian.Serializer
+
+    def from_token("User:" <> user_id) do
+      # Find and return the user object
+      {:ok, %{id: user_id}}
+    end
+    def from_token(_token) do
+      {:error, "Invalid token"}
+    end
+
+    def for_token(user) do
+      # Serialize the user into a single token
+    end
+  end
+  ```
+
+  In this example, all further requests will be made as User 5.
+
+  ## Options
+
+  The following options can be set when instantiating the plug.
+
+  * `param_name` - The query string parameter that is used to load the
+    current resource. Defaults to `as`.
+  * `serializer` - The serializer to be used to load the current
+    resource. Defaults to the serializer configured in your app's
+    Guardian config.
+
+
+  [hound]: https://github.com/HashNuke/hound
+  """
+  import Plug.Conn
+
+  @doc false
+  def init(opts \\ %{}) do
+    opts = Enum.into(opts, %{})
+
+    serializer = Map.get(opts, :serializer, Guardian.serializer)
+    param_name = Map.get(opts, :param_name, "as")
+
+    %{
+      serializer: serializer,
+      param_name: param_name
+    }
+  end
+
+  @doc false
+  def call(conn, %{serializer: serializer, param_name: param_name}) do
+    resource_token = get_backdoor_param_value(conn, param_name)
+
+    if resource_token do
+      conn = case load_resource(resource_token, serializer) do
+        {:ok, obj} -> Guardian.Plug.sign_in(conn, obj)
+        {:error, reason} -> handle_error(conn, reason, param_name)
+      end
+    end
+
+    conn
+  end
+
+  defp load_resource(token, serializer) do
+    serializer.from_token(token)
+  end
+
+  defp get_backdoor_param_value(conn, param_name) do
+    conn
+    |> fetch_query_params
+    |> Map.get(:params)
+    |> Map.get(param_name)
+  end
+
+  defp handle_error(conn, reason, param_name) do
+    conn
+    |> send_resp(500,
+      "Error while decoding \"#{param_name}\" parameter with the " <>
+      "Guardian.Plug.Backdoor plug:\n#{reason}")
+    |> halt
+  end
+end

--- a/test/guardian/integration_tests/backdoor_test.exs
+++ b/test/guardian/integration_tests/backdoor_test.exs
@@ -1,0 +1,92 @@
+defmodule Guardian.IntegrationTests.BackdoorTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use Plug.Test
+  import Guardian.TestHelper
+
+  defmodule SampleSerializer do
+    @moduledoc false
+    @behaviour Guardian.Serializer
+
+    def from_token("User:" <> user_id) do
+      {:ok, %{id: user_id}}
+    end
+    def from_token(token) do
+      {:error, "Invalid token #{token}"}
+    end
+
+    def for_token(%{id: user_id}) do
+      {:ok, "User:" <> user_id}
+    end
+  end
+
+  # Created a pipeline so plug can actually run through the compilation steps
+  # and report any invalid init methods when compiling
+  defmodule BackdoorVerifySessionPipeline do
+    @moduledoc false
+    use Plug.Builder
+
+    plug Guardian.Plug.Backdoor, serializer: SampleSerializer
+    plug Guardian.Plug.VerifySession
+    plug Guardian.Plug.LoadResource
+  end
+
+  test "request with backdoor param set to exactly what serializer expects" do
+    conn = conn(:get, "/?as=User:15")
+
+    conn = conn
+      |> conn_with_fetched_session
+      |> BackdoorVerifySessionPipeline.call(%{})
+
+    resource = Guardian.Plug.current_resource(conn)
+
+    assert resource == %{id: "15"}
+    assert Guardian.Plug.authenticated?(conn)
+  end
+
+  test "request with backdoor param set to something unexpected" do
+    conn = conn(:get, "/?as=invalid")
+
+    conn = conn
+      |> conn_with_fetched_session
+      |> BackdoorVerifySessionPipeline.call(%{})
+
+    refute Guardian.Plug.current_resource(conn)
+    refute Guardian.Plug.authenticated?(conn)
+  end
+
+  test "request without as parameter set" do
+    conn = conn(:get, "/")
+
+    conn =
+      conn
+      |> conn_with_fetched_session
+      |> BackdoorVerifySessionPipeline.call(%{})
+
+    refute Guardian.Plug.current_resource(conn)
+    refute Guardian.Plug.authenticated?(conn)
+  end
+
+  defmodule BackdoorVerifyHeaderPipeline do
+    @moduledoc false
+    use Plug.Builder
+
+    plug Guardian.Plug.Backdoor, serializer: SampleSerializer
+    plug Guardian.Plug.VerifyHeader
+    plug Guardian.Plug.LoadResource
+  end
+
+  test "VerifyHeader request with backdoor param set to exactly what serializer expects" do
+    conn = conn(:get, "/?as=User:15")
+
+    conn =
+      conn
+      |> conn_with_fetched_session
+      |> BackdoorVerifyHeaderPipeline.call(%{})
+
+    resource = Guardian.Plug.current_resource(conn)
+
+    assert resource == %{id: "15"}
+    assert Guardian.Plug.authenticated?(conn)
+  end
+end

--- a/test/guardian/plug/backdoor_test.exs
+++ b/test/guardian/plug/backdoor_test.exs
@@ -1,0 +1,90 @@
+defmodule Guardian.Plug.BackdoorTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use Plug.Test
+  import Guardian.TestHelper
+
+  test "sets the current resource with the default serializer" do
+    conn = conn(:get, "/?as=User:15")
+
+    current_resource =
+      conn
+      |> conn_with_fetched_session
+      |> run_plug(Guardian.Plug.Backdoor)
+      |> Guardian.Plug.current_resource
+
+    {:ok, deserialized_resource} = Guardian.serializer.from_token("User:15")
+    assert current_resource == deserialized_resource
+  end
+
+  defmodule SampleSerializer do
+    @moduledoc false
+    @behaviour Guardian.Serializer
+
+    def from_token("User:" <> user_id) do
+      {:ok, %{id: user_id}}
+    end
+    def from_token(token) do
+      {:error, "Unable to find resource for token: '#{token}'."}
+    end
+
+    def for_token(%{id: user_id}) do
+      {:ok, "User:" <> user_id}
+    end
+  end
+
+  test "sets the current resource with the given serializer" do
+    conn = conn(:get, "/?as=User:15")
+
+    current_resource = conn
+      |> conn_with_fetched_session
+      |> run_plug(Guardian.Plug.Backdoor, serializer: SampleSerializer)
+      |> Guardian.Plug.current_resource
+
+    {:ok, deserialized_resource} = SampleSerializer.from_token("User:15")
+    assert current_resource == deserialized_resource
+  end
+
+  test "allows the backdoor param to be overridden" do
+    conn = conn(:get, "/?impersonate=User:15")
+
+    current_resource =
+      conn
+      |> conn_with_fetched_session
+      |> run_plug(Guardian.Plug.Backdoor, serializer: SampleSerializer,
+          param_name: "impersonate")
+      |> Guardian.Plug.current_resource
+
+    {:ok, deserialized_resource} = SampleSerializer.from_token("User:15")
+    assert current_resource == deserialized_resource
+  end
+
+  test "does nothing if the param is not given" do
+    conn = conn(:get, "/")
+
+    conn =
+      conn
+      |> conn_with_fetched_session
+      |> run_plug(Guardian.Plug.Backdoor, serializer: SampleSerializer)
+
+    current_resource = Guardian.Plug.current_resource(conn)
+
+    assert current_resource == nil
+    refute Guardian.Plug.authenticated?(conn)
+    refute conn.halted
+  end
+
+  test "halts and returns an error when the serializer can't find the object" do
+    conn = conn(:get, "/?as=invalid")
+
+    conn =
+      conn
+      |> conn_with_fetched_session
+      |> run_plug(Guardian.Plug.Backdoor, serializer: SampleSerializer)
+
+    {status, _, _body} = sent_resp(conn)
+
+    assert status == 500
+    assert conn.halted
+  end
+end


### PR DESCRIPTION
This plug helps developers write faster acceptance tests, by not requiring to go through the entire sign in process for each test. This feature is inspired by Clearance’s backdoor: https://github.com/thoughtbot/clearance#fast-feature-specs

Any feedback is welcome and greatly appreciated.

Fixes #90.
