### PR TITLE
fix do_refresh! revoke! call

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -184,7 +184,7 @@ defmodule Guardian do
 
     case encode_and_sign(resource, type, new_claims) do
       {:ok, jwt, full_claims} ->
-        revoke!(jwt, claims)
+        revoke!(jwt, claims, %{})
         {:ok, jwt, full_claims}
       {:error, reason} -> {:error, reason}
     end


### PR DESCRIPTION
I'm new to elixir, but from what I can see. when refresh was implemented the revoke! function had two signatures. 
`revoke!(jwt)` and `revoke!(jwt, claims)`
at this point, do_refresh! was calling `revoke!\2` and all is well.
(reference: https://github.com/ueberauth/guardian/commit/018233d669b0b8b8d6aa481502f8a65930c0abe5)

when the commit "Allow using custom secrets to encode / decode tokens" came in the revoke signatures changed to 
`revoke!(jwt, params \\ %{})` and `revoke!(jwt, claims, _params)`
however the call to revoke! in do_refresh! did not change.
(reference: https://github.com/ueberauth/guardian/commit/c2fb7154950d371ea7f71a4d3dbe38228baa1c27)

This is leading to do_refresh! calling revoke hooks with the claims from the newly refreshed jwt instead of the claims passed into do_refresh!