### PR TITLE
Support for secret keys other than "oct"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Master (Unreleased)
 
+* Support for secret keys other than "oct" which provides support for signature
+  algorithms other than HSxxx. See #122
+
 # v 0.10.1
 
 * Fix error in Guardian.Plug.ErrorHandler when Accept header is unset.

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :guardian, Guardian,
       issuer: "MyApp",
-      allowed_algos: ["HS512"],
+      allowed_algos: ["HS512", "ES512"],
       ttl: { 1, :days },
       verify_issuer: true,
       secret_key: "woiuerojksldkjoierwoiejrlskjdf",

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -289,10 +289,11 @@ defmodule Guardian do
     Map.merge(%{"alg" => hd(allowed_algos)}, headers)
   end
 
-  defp jose_jwk(the_secret) do
-    secret = the_secret || config(:secret_key)
-    %{"kty" => "oct", "k" => :base64url.encode(secret)}
-  end
+  defp jose_jwk(the_secret = %JOSE.JWK{}), do: the_secret
+  defp jose_jwk(the_secret) when is_binary(the_secret), do: JOSE.JWK.from_oct(the_secret)
+  defp jose_jwk(the_secret) when is_function(the_secret, 0), do: the_secret.()
+  defp jose_jwk(the_secret) when is_map(the_secret), do: JOSE.JWK.from_map(the_secret)
+  defp jose_jwk(nil), do: jose_jwk(config(:secret_key) || false)
 
   defp encode_claims(claims) do
     {headers, claims} = strip_value(claims, "headers", %{})

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,9 @@
 %{"base64url": {:hex, :base64url, "0.0.1"},
-  "bunt": {:hex, :bunt, "0.1.4"},
-  "credo": {:hex, :credo, "0.3.1"},
-  "dogma": {:hex, :dogma, "0.0.11"},
-  "earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "joken": {:hex, :joken, "0.16.1"},
-  "jose": {:hex, :jose, "1.6.0"},
-  "plug": {:hex, :plug, "1.0.2"},
+  "bunt": {:hex, :bunt, "0.1.5"},
+  "credo": {:hex, :credo, "0.3.5"},
+  "earmark": {:hex, :earmark, "0.2.1"},
+  "ex_doc": {:hex, :ex_doc, "0.11.4"},
+  "jose": {:hex, :jose, "1.7.0"},
+  "plug": {:hex, :plug, "1.1.2"},
   "poison": {:hex, :poison, "2.1.0"},
-  "uuid": {:hex, :uuid, "1.1.1"}}
+  "uuid": {:hex, :uuid, "1.1.3"}}


### PR DESCRIPTION
This pull request allows the `secret_key` to be any valid `%JOSE.JWK{}` struct, binary, map, or an arity 0 function that returns one of those types.

 * Binary keys are loaded using `JOSE.JWK.from_oct/1` which allows these changes to maintain backwards compatibility.
 * Map keys are loaded using `JOSE.JWK.from_map/1`.
 * Function keys are called if the arity of the function is 0.
 * `%JOSE.JWK{}` struct keys are left untouched.

This allows you to do things like this:

##### Map

See [here](https://gist.github.com/potatosalad/925a8b74d85835e285b9) for examples of all key types.

See the [key generation](https://hexdocs.pm/jose/key-generation.html) docs from jose for how to generate your own.

```elixir
config :guardian, Guardian,
  allowed_algos: ["ES512"],
  secret_key: %{
    "crv" => "P-521",
    "d" => "axDuTtGavPjnhlfnYAwkHa4qyfz2fdseppXEzmKpQyY0xd3bGpYLEF4ognDpRJm5IRaM31Id2NfEtDFw4iTbDSE",
    "kty" => "EC",
    "x" => "AL0H8OvP5NuboUoj8Pb3zpBcDyEJN907wMxrCy7H2062i3IRPF5NQ546jIJU3uQX5KN2QB_Cq6R_SUqyVZSNpIfC",
    "y" => "ALdxLuo6oKLoQ-xLSkShv_TA0di97I9V92sg1MKFava5hKGST1EKiVQnZMrN3HO8LtLT78SNTgwJSQHAXIUaA-lV"
  }
```

##### Function

I dunno, maybe you like storing your RSA private keys in [redis](http://redis.io/), [consul](https://www.consul.io/), [etcd](https://coreos.com/etcd/), [zookeeper](https://zookeeper.apache.org/), [vault](https://www.vaultproject.io/), [keywhiz](https://github.com/square/keywhiz), or exclusively using [IP over Avian Carriers](https://en.wikipedia.org/wiki/IP_over_Avian_Carriers).

Here's an example using [redix](https://github.com/whatyouhide/redix):

```elixir
config :guardian, Guardian,
  allowed_algos: ["RS512"],
  secret_key: fn ->
    # Bad example. An already established connection should be used and possibly cache the value locally.
    {:ok, conn} = Redix.start_link
    rsa_jwk = conn
      |> Redix.command!(["GET my-rsa-key"])
      |> JOSE.JWK.from_binary
    Redix.stop(conn)
    rsa_jwk
  end
```

##### `%JOSE.JWK{}` Struct

If you're a fan of environment variables, but only want to load the secret key once, this is the example for you.

This example loads an encrypted JWK using `JOSE.JWK.from_file/2` with the file and passphrase provided by environment variables.

```elixir
config :guardian, Guardian,
  allowed_algos: ["Ed25519"],
  secret_key: System.get_env("SECRET_KEY_PASSPHRASE") |> JOSE.JWK.from_file(System.get_env("SECRET_KEY_FILE"))
```

The encrypted JWK file can be created like this (see [&ldquo;Curve25519 and Curve448 Support&rdquo;](https://github.com/potatosalad/erlang-jose#curve25519-and-curve448-support) for more information about `Ed25519` keys):

```elixir
# unless you have libdecaf or libsodium installed, you'll need to enable crypto fallback
JOSE.crypto_fallback(true)
jwk = JOSE.JWK.generate_key({:okp, :Ed25519})
JOSE.JWK.to_file("my super secret passphrase", "secret-jwk-ed25519.json", jwk)
```
