### PR TITLE
use resource from conn if already present

### DIFF
--- a/lib/guardian/plug/load_resource.ex
+++ b/lib/guardian/plug/load_resource.ex
@@ -21,9 +21,7 @@ defmodule Guardian.Plug.LoadResource do
     key = Map.get(opts, :key, :default)
 
     case Guardian.Plug.current_resource(conn, key) do
-      {:ok, _} -> conn
-      {:error, _} -> conn
-      _ ->
+      nil ->
         case Guardian.Plug.claims(conn, key) do
           {:ok, claims} ->
             result = Guardian.serializer.from_token(Map.get(claims, "sub"))
@@ -31,6 +29,7 @@ defmodule Guardian.Plug.LoadResource do
           {:error, _} -> Guardian.Plug.set_current_resource(conn, nil, key)
           _ -> Guardian.Plug.set_current_resource(conn, nil, key)
         end
+      _ -> conn
     end
   end
 

--- a/test/guardian/plug/load_resource_test.exs
+++ b/test/guardian/plug/load_resource_test.exs
@@ -1,0 +1,39 @@
+defmodule Guardian.Plug.LoadResourceTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use Plug.Test
+  import Guardian.TestHelper
+
+  alias Guardian.Plug.LoadResource
+
+  setup do
+    conn = conn_with_fetched_session(conn(:get, "/"))
+    {:ok, %{conn: conn}}
+  end
+
+  test "with a resource already set", %{conn: conn} do
+    conn = conn
+    |> Guardian.Plug.set_current_resource(:the_resource)
+    |> run_plug(LoadResource)
+    assert Guardian.Plug.current_resource(conn) == :the_resource
+  end
+
+  test "with no resource set and no claims", %{conn: conn} do
+    conn = run_plug(conn, LoadResource)
+    assert Guardian.Plug.current_resource(conn) == nil
+  end
+
+  test "with no resource set and erroneous claims", %{conn: conn} do
+    conn = conn
+    |> Guardian.Plug.set_claims({:error, :some_error})
+    |> run_plug(LoadResource)
+    assert Guardian.Plug.current_resource(conn) == nil
+  end
+
+  test "with no resource set and valid claims", %{conn: conn} do
+    conn = conn
+    |> Guardian.Plug.set_claims({:ok, %{"sub" => "User:42"}})
+    |> run_plug(LoadResource)
+    assert Guardian.Plug.current_resource(conn) == "User:42"
+  end
+end


### PR DESCRIPTION
I noticed that the `LoadResource` assumed that the resource was inside a `{:ok, resource}` tuple inside the `conn`. `Guardian.Plug.set_current_resource` however just puts the resource into the `conn` without wrapping it in a tuple. This made testing a bit hard. With this fix it's possible to just use a helper like the following in controller tests:
```elixir
def sign_in(conn, user \\ %User{}) do
  conn
    |> Guardian.Plug.set_claims({:ok, %{}})
    |> Guardian.Plug.set_current_resource(user)
end
```
