### PR TITLE
loosen poison requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Guardian.Mixfile do
 
   defp deps do
     [{:jose, "~> 1.6"},
-     {:poison, "~> 2.1"},
+     {:poison, ">= 1.3.0 and < 3.0.0"},
      {:plug, "~> 1.0"},
      {:ex_doc, "~> 0.10", only: :docs},
      {:earmark, ">= 0.0.0", only: :docs},

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Guardian.Mixfile do
 
   defp deps do
     [{:jose, "~> 1.6"},
-     {:poison, ">= 1.3.0 and < 3.0.0"},
+     {:poison, ">= 1.3.0"},
      {:plug, "~> 1.0"},
      {:ex_doc, "~> 0.10", only: :docs},
      {:earmark, ">= 0.0.0", only: :docs},


### PR DESCRIPTION
this allows poison versions required by the current `phoenix_ecto` version. tests are still green, so maybe poison `~> 2.1` is not actually required yet