### PR TITLE
Fix: change doc to reflect actual behavior for Guardian.Plug.sign_in

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -86,7 +86,7 @@ defmodule Guardian.Plug do
   into the current web session.
 
   By specifying the 'type' of the token,
-  you're setting the aud field in the JWT.
+  you're setting the typ field in the JWT.
   """
   @spec sign_in(Plug.Conn.t, any, atom | String.t) :: Plug.Conn.t
   def sign_in(conn, object, type), do: sign_in(conn, object, type, %{})

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -234,7 +234,6 @@ defmodule Guardian.PlugTest do
     assert claims["typ"] == "token"
   end
 
-
   test "api_sign_in(object) error", context do
     conn = context.conn
            |> Guardian.Plug.api_sign_in(%{error: :unknown})

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -231,7 +231,9 @@ defmodule Guardian.PlugTest do
 
     assert claims["sub"]["user"] == "here"
     assert claims["here"] == "we are"
+    assert claims["typ"] == "token"
   end
+
 
   test "api_sign_in(object) error", context do
     conn = context.conn


### PR DESCRIPTION
This was mainly to confirm my own understanding. The docs say passing a type to the Guardian.Plug.sign_in/3 or Guardian.Plug.sign_in/4 functions will set the 'aud' field on the JWT. However, my reading of Guadrian.encode_and_sign suggests it sets the 'typ' field instead.