### PR TITLE
Refactor utils.ex with ":os.system_time" rather than ":os.timestamp"

### DIFF
--- a/lib/guardian/utils.ex
+++ b/lib/guardian/utils.ex
@@ -13,7 +13,6 @@ defmodule Guardian.Utils do
 
   @doc false
   def timestamp do
-    {mgsec, sec, _usec} = :os.timestamp
-    mgsec * 1_000_000 + sec
+    :os.system_time(:seconds)
   end
 end


### PR DESCRIPTION
Seems like there is a built-in method in erlang to fetch seconds from `:os.timestamp` http://erlang.org/doc/man/os.html