### PR TITLE
Fix for a Dialyzer type matching

### DIFF
--- a/lib/guardian/hooks.ex
+++ b/lib/guardian/hooks.ex
@@ -31,13 +31,13 @@ defmodule Guardian.Hooks do
   defcallback before_encode_and_sign(
     resource :: term,
     type :: atom,
-    claims :: Map
+    claims :: map()
   )
 
   defcallback after_encode_and_sign(
     resource :: term,
     type :: atom,
-    claims :: Map,
+    claims :: map(),
     token :: String.t
   )
 
@@ -52,12 +52,12 @@ defmodule Guardian.Hooks do
   )
 
   defcallback on_verify(
-    claims :: Map,
+    claims :: map(),
     jwt :: String.t
   )
 
   defcallback on_revoke(
-    claims :: Map,
+    claims :: map(),
     jwt :: String.t
   )
 end


### PR DESCRIPTION
Had to change `Map` type to `map()` because of dialyzer errors like
```
guardian_db.ex:103: The specified type for the 3rd argument of after_encode_and_sign/4 (#{}) is not a supertype of 'Elixir.Map', which is expected type for this argument in the callback of the 'Elixir.Guardian.Hooks' behaviour
```