### PR TITLE
Allow to exclude some controller actions from authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ end
 
 The failure function must receive the connection, and the connection params.
 
+It is also possible to pass a list of actions to be excluded from authentication.
+This can be useful for signup. Here you could exclude the `:new` and `:create` actions
+in the UserController (or whatever handles your signup).
+
+```elixir
+defmodule MyApp.MyController do
+  use MyApp.Web, :controller
+
+  plug Guardian.Plug.EnsureAuthenticated, handler: MyApp.MyAuthErrorHandler, except: [:new, :create]
+end
+```
+
 ### Guardian.Plug.LoadResource
 
 Up to now the other plugs have been just looking for valid tokens in various
@@ -196,7 +208,7 @@ If no set matches, the `:unauthorized` function is called.
 defmodule MyApp.MyController do
   use MyApp.Web, :controller
 
-  plug Guardian.Plug.EnsurePermissions, handler: MyApp.MyAuthErrorHandler, 
+  plug Guardian.Plug.EnsurePermissions, handler: MyApp.MyAuthErrorHandler,
     one_of: [%{default: [:read, :write]}, %{other: [:read]}]
 end
 ```

--- a/lib/guardian/plug/ensure_authenticated.ex
+++ b/lib/guardian/plug/ensure_authenticated.ex
@@ -43,7 +43,9 @@ defmodule Guardian.Plug.EnsureAuthenticated do
   def call(conn, opts) do
     key = Map.get(opts, :key, :default)
 
-    phoenix_action = Map.get(conn, :private) |> Map.get(:phoenix_action)
+    phoenix_action = conn
+      |> Map.get(:private)
+      |> Map.get(:phoenix_action)
     allowed_actions = Map.get(opts, :except)
 
     if is_list(allowed_actions) && Enum.member?(allowed_actions, phoenix_action) do

--- a/lib/guardian/plug/ensure_authenticated.ex
+++ b/lib/guardian/plug/ensure_authenticated.ex
@@ -16,6 +16,9 @@ defmodule Guardian.Plug.EnsureAuthenticated do
 
       plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule, aud: "token"
 
+      # It is also possible to exclude actions from authentication
+      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule, except: [:new, :create]
+
   If the handler option is not passed, `Guardian.Plug.ErrorHandler` will provide
   the default behavior.
   """
@@ -27,11 +30,12 @@ defmodule Guardian.Plug.EnsureAuthenticated do
     opts = Enum.into(opts, %{})
     handler = build_handler_tuple(opts)
 
-    claims_to_check = Map.drop(opts, [:on_failure, :key, :handler])
+    claims_to_check = Map.drop(opts, [:on_failure, :key, :handler, :except])
     %{
       handler: handler,
       key: Map.get(opts, :key, :default),
-      claims: Guardian.Utils.stringify_keys(claims_to_check)
+      claims: Guardian.Utils.stringify_keys(claims_to_check),
+      except: Map.get(opts, :except) || []
     }
   end
 
@@ -39,10 +43,17 @@ defmodule Guardian.Plug.EnsureAuthenticated do
   def call(conn, opts) do
     key = Map.get(opts, :key, :default)
 
-    case Guardian.Plug.claims(conn, key) do
-      {:ok, claims} -> conn |> check_claims(opts, claims)
-      {:error, reason} -> handle_error(conn, {:error, reason}, opts)
-      _ -> handle_error(conn, {:error, :no_session}, opts)
+    phoenix_action = Map.get(conn, :private) |> Map.get(:phoenix_action)
+    allowed_actions = Map.get(opts, :except)
+
+    if is_list(allowed_actions) && Enum.member?(allowed_actions, phoenix_action) do
+      conn
+    else
+      case Guardian.Plug.claims(conn, key) do
+        {:ok, claims} -> conn |> check_claims(opts, claims)
+        {:error, reason} -> handle_error(conn, {:error, reason}, opts)
+        _ -> handle_error(conn, {:error, :no_session}, opts)
+      end
     end
   end
 


### PR DESCRIPTION
Add option to Guardian.Plug.EnsureAuthenticated to allow controller actions to be excluded from authentication.

Refers to this [issue](https://github.com/ueberauth/guardian/issues/180).

From Readme:

It is also possible to pass a list of actions to be excluded from authentication.
This can be useful for signup. Here you could exclude the `:new` and `:create` actions
in the UserController (or whatever handles your signup).

```elixir
defmodule MyApp.MyController do
  use MyApp.Web, :controller

  plug Guardian.Plug.EnsureAuthenticated, handler: MyApp.MyAuthErrorHandler, except: [:new, :create]
end
```