### PR TITLE
Adding integration tests

### DIFF
--- a/test/integration/header_auth_test.exs
+++ b/test/integration/header_auth_test.exs
@@ -1,0 +1,35 @@
+defmodule Guardian.Integration.HeaderAuthTest do
+  @moduledoc false
+  use ExUnit.Case
+  use Plug.Test
+  import Guardian.TestHelper
+
+  alias Guardian.Plug.LoadResource
+  alias Guardian.Plug.VerifyHeader
+  alias Guardian.Claims
+
+  defmodule TestSerializer do
+    @moduledoc false
+    @behaviour Guardian.Serializer
+
+    def from_token("Org:" <> id), do: {:ok, id}
+    def for_token(_), do: {:ok, nil}
+  end
+
+  test "load current resource with a valid jwt in authorization header" do
+    claims = Claims.app_claims(%{"sub" => "Org:37", "aud" => "aud"})
+    jwt = build_jwt(claims)
+
+    conn = conn(:get, "/")
+
+    conn =
+      conn
+      |> put_req_header("authorization", jwt)
+      |> run_plug(VerifyHeader)
+      |> run_plug(LoadResource, serializer: TestSerializer)
+
+    assert Guardian.Plug.current_resource(conn) == "37"
+    assert Guardian.Plug.claims(conn) == {:ok, claims}
+    assert Guardian.Plug.current_token(conn) == jwt
+  end
+end

--- a/test/integration/session_auth_test.exs
+++ b/test/integration/session_auth_test.exs
@@ -1,0 +1,37 @@
+defmodule Guardian.Integration.SessionAuthTest do
+  @moduledoc false
+  use ExUnit.Case
+  use Plug.Test
+
+  import Guardian.TestHelper
+
+  alias Guardian.Plug.LoadResource
+  alias Guardian.Plug.VerifySession
+  alias Guardian.Claims
+
+  defmodule TestSerializer do
+    @moduledoc false
+    @behaviour Guardian.Serializer
+
+    def from_token("Company:" <> id), do: {:ok, id}
+    def for_token(_), do: {:ok, nil}
+  end
+
+  test "load current resource with a valid jwt in session" do
+    claims = Claims.app_claims(%{"sub" => "Company:42", "aud" => "aud"})
+    jwt = build_jwt(claims)
+
+    conn = conn(:get, "/")
+
+    conn =
+      conn
+      |> conn_with_fetched_session
+      |> put_session(Guardian.Keys.base_key(:default), jwt)
+      |> run_plug(VerifySession)
+      |> run_plug(LoadResource, serializer: TestSerializer)
+
+    assert Guardian.Plug.current_resource(conn) == "42"
+    assert Guardian.Plug.claims(conn) == {:ok, claims}
+    assert Guardian.Plug.current_token(conn) == jwt
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -51,6 +51,19 @@ defmodule Guardian.TestHelper do
     opts = apply(plug_module, :init, [plug_opts])
     apply(plug_module, :call, [conn, opts])
   end
+
+  def build_jwt(claims) do
+    config = Application.get_env(:guardian, Guardian)
+    algo = hd(Keyword.get(config, :allowed_algos))
+    secret = Keyword.get(config, :secret_key)
+
+    jose_jws = %{"alg" => algo}
+    jose_jwk = %{"kty" => "oct", "k" => :base64url.encode(secret)}
+    {_, jwt} = jose_jwk
+                 |> JOSE.JWT.sign(jose_jws, claims)
+                 |> JOSE.JWS.compact
+    jwt
+  end
 end
 
 ExUnit.start()


### PR DESCRIPTION
This adds integration tests to ensure the interactions between multiple plugs work as expected. These tests cover the `VerifyHeader` + `LoadResource` and `VerifySession` + `LoadResource` plug interactions. I also added a `build_jwt` test helper that will make writing these tests simpler.

I also added a `:serializer` option to the `Guardian.Plug.LoadResource` plug. This makes writing tests much more explicit as to how the current resource is deserialized from the `sub` claim.

Let me know what you think. I'm trying to get back to working on pull request #120, and I think integration tests would be super helpful in making sure that interactions between multiple plugs work as expected.