### PR TITLE
catch all errors on verify_session call instead of just :no_session

### DIFF
--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -28,7 +28,7 @@ defmodule Guardian.Plug.VerifySession do
 
     case Guardian.Plug.claims(conn, key) do
       {:ok, _} -> conn
-      {:error, :no_session} ->
+      {:error, _} ->
         jwt = Plug.Conn.get_session(conn, base_key(key))
 
         if jwt do


### PR DESCRIPTION
Pull request in regards to: https://github.com/ueberauth/guardian/issues/210