### PR TITLE
Enum map without getting keys first in Guardian.Utils

### DIFF
--- a/lib/guardian/utils.ex
+++ b/lib/guardian/utils.ex
@@ -3,12 +3,16 @@ defmodule Guardian.Utils do
   @doc false
   def stringify_keys(nil), do: %{}
   def stringify_keys(map) do
-    Enum.reduce(
-      Map.keys(map), %{},
-      fn(k,acc) ->
-        Map.put(acc, to_string(k), map[k])
-      end
-    )
+    Enum.reduce_while(map, nil, fn
+      {key, _}, nil when is_binary(key) -> {:cont, nil}
+      _, _ -> {:halt, do_stringify_keys(map)}
+    end) || map
+  end
+
+  defp do_stringify_keys(map) do
+    Enum.reduce(map, Map.new, fn {key, value}, acc ->
+      Map.put(acc, to_string(key), value)
+    end)
   end
 
   @doc false

--- a/test/guardian/utils_test.exs
+++ b/test/guardian/utils_test.exs
@@ -3,7 +3,9 @@ defmodule Guardian.UtilsTest do
   use ExUnit.Case, async: true
 
   test "stringify_keys" do
+    assert Guardian.Utils.stringify_keys(nil) == %{}
     assert Guardian.Utils.stringify_keys(%{foo: "bar"}) == %{"foo" => "bar"}
+    assert Guardian.Utils.stringify_keys(%{"foo" => "bar"}) == %{"foo" => "bar"}
   end
 
   test "timestamp" do


### PR DESCRIPTION
The pull request did two things:

- [*] Avoid fetching keys from map before enumerating map( map is enumerable)

- [*] Do not stringify a map that has been stringified.