### PR TITLE
update behaviours to reflect changes made in elixir 1.4

### DIFF
--- a/lib/guardian/claim_validation.ex
+++ b/lib/guardian/claim_validation.ex
@@ -9,9 +9,7 @@ defmodule Guardian.ClaimValidation do
 
       use Guardian.ClaimValidation
   """
-  use Behaviour
-
-  defcallback validate_claim(String.t, map, map) :: :ok |
+  @callback validate_claim(String.t, map, map) :: :ok |
                                                         {:error, atom}
 
   defmacro __using__(_options \\ []) do

--- a/lib/guardian/hooks.ex
+++ b/lib/guardian/hooks.ex
@@ -2,7 +2,6 @@ defmodule Guardian.Hooks do
   @moduledoc """
   This module helps to hook into the lifecycle of authentication.
   """
-  use Behaviour
 
   defmacro __using__(_) do
     quote do
@@ -28,38 +27,38 @@ defmodule Guardian.Hooks do
     end
   end
 
-  defcallback before_encode_and_sign(
+  @callback before_encode_and_sign(
     resource :: term,
     type :: atom,
     claims :: map()
-  )
+  ) :: {:ok, {term, atom, map}}
 
-  defcallback after_encode_and_sign(
+  @callback after_encode_and_sign(
     resource :: term,
     type :: atom,
     claims :: map(),
     token :: String.t
-  )
+  ) :: Plug.Conn.t
 
-  defcallback after_sign_in(
+  @callback after_sign_in(
     conn :: Plug.Conn.t,
     location :: atom | nil
-  )
+  ) :: Plug.Conn.t
 
-  defcallback before_sign_out(
+  @callback before_sign_out(
     conn :: Plug.Conn.t,
     location :: atom | nil
-  )
+  ) :: Plug.Conn.t
 
-  defcallback on_verify(
+  @callback on_verify(
     claims :: map(),
     jwt :: String.t
-  )
+  ) :: {:ok, {map(), String.t}}
 
-  defcallback on_revoke(
+  @callback on_revoke(
     claims :: map(),
     jwt :: String.t
-  )
+  ) :: {:ok, {map(), String.t}}
 end
 
 defmodule Guardian.Hooks.Default do

--- a/lib/guardian/serializer.ex
+++ b/lib/guardian/serializer.ex
@@ -6,17 +6,16 @@ defmodule Guardian.Serializer do
   the resource from the encoded value in the JWT and also encoding a resource
   into a String so that it may be stored in the JWT
   """
-  use Behaviour
 
   @doc """
   Serializes the object into the token. Suggestion: \"User:2\"
   """
-  defcallback for_token(object :: term) :: {:ok, String.t} |
+  @callback for_token(object :: term) :: {:ok, String.t} |
                                            {:error, String.t}
 
   @doc """
   De-serializes the object from a token
   """
-  defcallback from_token(subject :: String.t) :: {:ok, object :: term} |
+  @callback from_token(subject :: String.t) :: {:ok, object :: term} |
                                                  {:error, String.t}
 end


### PR DESCRIPTION
There were some warning when running elixir 1.4. I've test on elixir 1.3.4 an 1.4. All test return successfully

```
warning: the Behaviour module is deprecated. Instead of using this module, use the @callback and @macrocallback module attributes. See the documentation for Module for more information on these attributes
  lib/guardian/claim_validation.ex:12: (module)
  (elixir) src/elixir_compiler.erl:125: :elixir_compiler.dispatch_loaded/6
  (elixir) src/elixir_module.erl:191: :elixir_module.eval_form/6
  (elixir) src/elixir_module.erl:71: :elixir_module.do_compile/5
  (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6

warning: the Behaviour module is deprecated. Instead of using this module, use the @callback and @macrocallback module attributes. See the documentation for Module for more information on these attributes
  lib/guardian/hooks.ex:5: (module)
  (elixir) src/elixir_compiler.erl:125: :elixir_compiler.dispatch_loaded/6
  (elixir) src/elixir_module.erl:191: :elixir_module.eval_form/6
  (elixir) src/elixir_module.erl:71: :elixir_module.do_compile/5
  (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6

warning: the Behaviour module is deprecated. Instead of using this module, use the @callback and @macrocallback module attributes. See the documentation for Module for more information on these attributes
  lib/guardian/serializer.ex:9: (module)
  (elixir) src/elixir_compiler.erl:125: :elixir_compiler.dispatch_loaded/6
  (elixir) src/elixir_module.erl:191: :elixir_module.eval_form/6
  (elixir) src/elixir_module.erl:71: :elixir_module.do_compile/5
  (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```