### PR TITLE
Fix `from_token` example on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ end
 Accessing the resource from a set of claims:
 
 ```elixir
-case Guardian.serializer.from_token(claims.sub) do
+case Guardian.serializer.from_token(claims["sub"]) do
   { :ok, resource } -> do_things_with_resource(resource)
   { :error, reason } -> do_things_without_a_resource(reason)
 end


### PR DESCRIPTION
The claims map as returned by `Guardian.decode_and_verify(jwt)` has an string key `"sub"` which must be given to `Guardian.serializer.from_token`.

Updated the README to reflect this, as accessing `claims.sub` would not work.