### PR TITLE
test before_encode_and_sign & after_encode_and_sign hooks

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -7,6 +7,7 @@ config :guardian, Guardian,
       verify_issuer: true,
       secret_key: "woiuerojksldkjoierwoiejrlskjdf",
       serializer: Guardian.TestGuardianSerializer,
+      hooks: Guardian.Hooks.Test,
       system_foo: {:system, "FOO"},
       permissions: %{
         default: [:read, :write, :update, :delete],

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -97,12 +97,14 @@ defmodule Guardian do
 
   defp encode_from_hooked({:ok, {resource, type, claims_from_hook}}) do
     {:ok, jwt} = encode_claims(claims_from_hook)
-    call_after_encode_and_sign_hook(
+    case call_after_encode_and_sign_hook(
       resource,
       type,
       claims_from_hook, jwt
-    )
-    {:ok, jwt, claims_from_hook}
+    ) do
+      :ok -> {:ok, jwt, claims_from_hook}
+      { :error, reason } -> {:error, reason}
+    end
   end
 
   defp encode_from_hooked({:error, _reason} = error), do: error

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -103,7 +103,7 @@ defmodule Guardian do
       claims_from_hook, jwt
     ) do
       :ok -> {:ok, jwt, claims_from_hook}
-      { :error, reason } -> {:error, reason}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -229,6 +229,26 @@ defmodule GuardianTest do
     assert reason
   end
 
+  test "encode_and_sign calls before_encode_and_sign hook" do
+    {:ok, _, _} = Guardian.encode_and_sign("before_encode_and_sign", "send")
+    assert_received :before_encode_and_sign
+  end
+
+  test "encode_and_sign calls before_encode_and_sign hook w/ error" do
+    {:error, reason} = Guardian.encode_and_sign("before_encode_and_sign", "error")
+    assert reason == "before_encode_and_sign_error"
+  end
+
+  test "encode_and_sign calls after_encode_and_sign hook" do
+    {:ok, _, _} = Guardian.encode_and_sign("after_encode_and_sign", "send")
+    assert_received :after_encode_and_sign
+  end
+
+  test "encode_and_sign calls after_encode_and_sign hook w/ error" do
+    {:error, reason} = Guardian.encode_and_sign("after_encode_and_sign", "error")
+    assert reason == "after_encode_and_sign_error"
+  end
+
   test "encode_and_sign with custom secret" do
     secret = "ABCDEF"
     {:ok, jwt, _} = Guardian.encode_and_sign(

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -79,6 +79,8 @@ defmodule Guardian.TestHelper do
 end
 
 defmodule Guardian.Hooks.Test do
+  @moduledoc false
+
   use Guardian.Hooks
 
   def before_encode_and_sign("before_encode_and_sign" = resource, "send" = type, claims) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -78,4 +78,32 @@ defmodule Guardian.TestHelper do
   end
 end
 
+defmodule Guardian.Hooks.Test do
+  use Guardian.Hooks
+
+  def before_encode_and_sign("before_encode_and_sign" = resource, "send" = type, claims) do
+    send self(), :before_encode_and_sign
+    {:ok, {resource, type, claims}}
+  end
+
+  def before_encode_and_sign("before_encode_and_sign", "error", _) do
+    {:error, "before_encode_and_sign_error"}
+  end
+
+  def before_encode_and_sign(resource, type, claims) do
+    {:ok, {resource, type, claims}}
+  end
+
+  def after_encode_and_sign("after_encode_and_sign", "send", _, _) do
+    send self(), :after_encode_and_sign
+    :ok
+  end
+
+  def after_encode_and_sign("after_encode_and_sign", "error", _, _) do
+    {:error, "after_encode_and_sign_error"}
+  end
+
+  def after_encode_and_sign(_, _, _, _), do: :ok
+end
+
 ExUnit.start()


### PR DESCRIPTION
verify before_encode_and_sign and after_encode_and_sign hooks are called
pattern match after_encode_and_sign on :ok or {:error, error}

In [GuarbianDB](https://github.com/hassox/guardian_db/blob/master/lib/guardian_db.ex#L74), after_encode_and_sign can return { :error, :token_storage_failure }

```
  def after_encode_and_sign(resource, type, claims, jwt) do
    case Token.create!(claims, jwt) do
      { :error, _ } -> { :error, :token_storage_failure }
      _ -> { :ok, { resource, type, claims, jwt } }
    end
  end
```

This change pattern matches so that the error is return from encode_from_hooked