### PR TITLE
plug to ensure load_resource actually worked

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ defmodule MySecretKey do
       |> JOSE.JWK.from_binary
     Redix.stop(conn)
     rsa_jwk
-  end  
+  end
 end
 
 config :guardian, Guardian,
@@ -112,7 +112,7 @@ config :guardian, Guardian,
 defmodule MySecretKey do
   def fetch do
     System.get_env("SECRET_KEY_PASSPHRASE") |> JOSE.JWK.from_file(System.get_env("SECRET_KEY_FILE"))
-  end  
+  end
 end
 
 config :guardian, Guardian,
@@ -183,7 +183,21 @@ resource from the Serializer and makes it available via
 
 Note that this does _not ensure_ a resource will be loaded.
 If there is no available resource (because it could not be found)
-`current_resource` will return nil.
+`current_resource` will return nil. You can ensure it's loaded with
+`Guardian.Plug.EnsureResource`
+
+### Guardian.Plug.EnsureResource
+
+Looks for a previously loaded resource. If not found, the `:no_resource`
+function is called on your handler.
+
+```elixir
+defmodule MyApp.MyController do
+  use MyApp.Web, :controller
+
+  plug Guardian.Plug.EnsureResource, handler: MyApp.MyAuthErrorHandler
+end
+```
 
 ### Guardian.Plug.EnsurePermissions
 

--- a/lib/guardian/plug/ensure_resource.ex
+++ b/lib/guardian/plug/ensure_resource.ex
@@ -1,0 +1,63 @@
+defmodule Guardian.Plug.EnsureResource do
+  @moduledoc """
+  This plug ensures that the current_resource has been set, usually in
+  Guardian.Plug.LoadResource.
+
+  If one is not found, the `no_resource/2` function is invoked with the
+  `Plug.Conn.t` object and its params.
+
+  ## Example
+
+      # Will call the no_resource/2 function on your handler
+      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule
+
+      # look in the :secret location.
+      plug Guardian.Plug.EnsureAuthenticated, handler: SomeModule, key: :secret
+
+  If the handler option is not passed, `Guardian.Plug.ErrorHandler` will provide
+  the default behavior.
+  """
+  require Logger
+  import Plug.Conn
+
+  @doc false
+  def init(opts) do
+    opts = Enum.into(opts, %{})
+    handler = build_handler_tuple(opts)
+
+    %{
+      handler: handler,
+      key: Map.get(opts, :key, :default)
+    }
+  end
+
+  @doc false
+  def call(conn, opts) do
+    key = Map.get(opts, :key, :default)
+
+    case Guardian.Plug.current_resource(conn, key) do
+      nil -> handle_error(conn, opts)
+      _ -> conn
+    end
+  end
+
+  defp handle_error(%Plug.Conn{params: params} = conn, opts) do
+    conn = conn |> assign(:guardian_failure, :no_resource) |> halt
+    params = Map.merge(params, %{reason: :no_resource})
+
+    {mod, meth} = Map.get(opts, :handler)
+
+    apply(mod, meth, [conn, params])
+  end
+
+  defp build_handler_tuple(%{handler: mod}) do
+    {mod, :no_resource}
+  end
+  defp build_handler_tuple(%{on_failure: {mod, fun}}) do
+    _ = Logger.warn(":on_failure is deprecated. Use the :handler option instead")
+    {mod, fun}
+  end
+  defp build_handler_tuple(_) do
+    {Guardian.Plug.ErrorHandler, :no_resource}
+  end
+end

--- a/lib/guardian/plug/error_handler.ex
+++ b/lib/guardian/plug/error_handler.ex
@@ -5,6 +5,7 @@ defmodule Guardian.Plug.ErrorHandler do
 
   @callback unauthenticated(Plug.Conn.t, map) :: Plug.Conn.t
   @callback unauthorized(Plug.Conn.t, map) :: Plug.Conn.t
+  @callback no_resource(Plug.Conn.t, map) :: Plug.Conn.t
 
   import Plug.Conn
 
@@ -13,6 +14,10 @@ defmodule Guardian.Plug.ErrorHandler do
   end
 
   def unauthorized(conn, _params) do
+    respond(conn, response_type(conn), 403, "Unauthorized")
+  end
+
+  def no_resource(conn, _params) do
     respond(conn, response_type(conn), 403, "Unauthorized")
   end
 

--- a/test/guardian/plug/ensure_resource_test.exs
+++ b/test/guardian/plug/ensure_resource_test.exs
@@ -1,0 +1,111 @@
+defmodule Guardian.Plug.EnsureResourceTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use Plug.Test
+  import ExUnit.CaptureLog
+  import Guardian.TestHelper
+
+  alias Guardian.Plug.EnsureResource
+
+  defmodule TestHandler do
+    @moduledoc false
+
+    def no_resource(conn, _) do
+      conn
+      |> Plug.Conn.assign(:guardian_spec, :no_resource)
+      |> Plug.Conn.send_resp(403, "Unauthorized")
+    end
+  end
+
+  setup do
+    conn = conn(:get, "/foo")
+    {:ok, %{conn: conn}}
+  end
+
+  test "init/1 sets the handler option to the module that's passed in" do
+    %{handler: handler_opts} = EnsureResource.init(handler: TestHandler)
+
+    assert handler_opts == {TestHandler, :no_resource}
+  end
+
+  test "init/1 sets the handler option to the value of on_failure" do
+    fun = fn ->
+      %{handler: handler_opts} = EnsureResource.init(
+        on_failure: {TestHandler, :custom_failure_method}
+      )
+
+      assert handler_opts == {TestHandler, :custom_failure_method}
+    end
+
+    assert capture_log([level: :warn], fun) =~ ":on_failure is deprecated"
+  end
+
+  test "init/1 defaults the handler option to Guardian.Plug.ErrorHandler" do
+    %{handler: handler_opts} = EnsureResource.init %{}
+
+    assert handler_opts == {Guardian.Plug.ErrorHandler, :no_resource}
+  end
+
+  test "init/1 with default options" do
+    options = EnsureResource.init %{}
+
+    assert options == %{
+      handler: {Guardian.Plug.ErrorHandler, :no_resource},
+      key: :default
+    }
+  end
+
+  test "with a resource already set doesn't call no_resource for default key", %{conn: conn} do
+    ensured_conn =
+      conn
+      |> Guardian.Plug.set_current_resource(:the_resource)
+      |> run_plug(EnsureResource, handler: TestHandler)
+
+    refute must_have_resource(ensured_conn)
+  end
+
+  test "with a resource already set doesn't call no_resource for key", %{conn: conn} do
+    ensured_conn =
+      conn
+      |> Guardian.Plug.set_current_resource(:the_resource, :secret)
+      |> run_plug(EnsureResource, handler: TestHandler, key: :secret)
+
+    refute must_have_resource(ensured_conn)
+  end
+
+  test "with no resource set calls no_resource for default key", %{conn: conn} do
+    ensured_conn = run_plug(
+      conn,
+      EnsureResource,
+      handler: TestHandler
+    )
+
+    assert must_have_resource(ensured_conn)
+  end
+
+  test "with no resource set calls no_resource for key", %{conn: conn} do
+    ensured_conn = run_plug(
+      conn,
+      EnsureResource,
+      handler: TestHandler,
+      key: :secret
+    )
+
+    assert must_have_resource(ensured_conn)
+  end
+
+  test "it halts the connection", %{conn: conn} do
+    ensured_conn = run_plug(
+      conn,
+      EnsureResource,
+      handler: TestHandler,
+      key: :secret
+    )
+
+    assert ensured_conn.halted
+  end
+
+  defp must_have_resource(conn) do
+    conn.assigns[:guardian_spec] == :no_resource
+  end
+end


### PR DESCRIPTION
When I first used Guardian it was strange that current_resource could be nil after calling the LoadResource plug. It still seems to be an [issue](https://github.com/ueberauth/guardian/issues/78). I decided to go for 3 pull requests and add it.

The discussion suggested using a new plug or updating LoadResource. I used a new plug because I didn't want to change LoadResources current behavior, but it could have gone either way, maybe with the plug looking like this:

```
plug Guardian.Plug.LoadResource, call_handler: true #assumes Guardian.Plug.ErrorHandler
plug Guardian.Plug.LoadResource, handler: MyApp.MyAuthErrorHandler
```

I'm not sure about the default return code or message. I also didn't know if it should call one of the existing error handler methods, but I figured leaving it explicit gives users of the plug the most flexibility. The code / specs / documentation was just copied and a few variables changed, so thanks for the great base to work in.