### PR TITLE
fix pattern miss match when use with GuardianDB

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -102,7 +102,7 @@ defmodule Guardian do
       type,
       claims_from_hook, jwt
     ) do
-      :ok -> {:ok, jwt, claims_from_hook}
+      {:ok, _} -> {:ok, jwt, claims_from_hook}
       {:error, reason} -> {:error, reason}
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -96,16 +96,18 @@ defmodule Guardian.Hooks.Test do
     {:ok, {resource, type, claims}}
   end
 
-  def after_encode_and_sign("after_encode_and_sign", "send", _, _) do
-    send self(), :after_encode_and_sign
-    :ok
-  end
-
   def after_encode_and_sign("after_encode_and_sign", "error", _, _) do
     {:error, "after_encode_and_sign_error"}
   end
 
-  def after_encode_and_sign(_, _, _, _), do: :ok
+  def after_encode_and_sign("after_encode_and_sign" = resource, "send" = type, claims, _) do
+    send self(), :after_encode_and_sign
+    {:ok, {resource, type, claims, "jwt"}}
+  end
+
+  def after_encode_and_sign(resource, type, claims, jwt) do
+    {:ok, {resource, type, claims, jwt}}
+  end
 end
 
 ExUnit.start()


### PR DESCRIPTION
Module Guardian line 105, changed `:ok` to `{:ok, _}`
