### PR TITLE
add typespecs for errors

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -41,8 +41,7 @@ defmodule Guardian do
   to obtain a value suitable for storage inside a JWT.
   """
   @spec encode_and_sign(any) :: {:ok, String.t, map} |
-                                {:error, atom} |
-                                {:error, String.t}
+                                {:error, any}
   def encode_and_sign(object), do: encode_and_sign(object, @default_token_type, %{})
 
   @doc """
@@ -52,8 +51,7 @@ defmodule Guardian do
   The type can be anything but suggested is "access".
   """
   @spec encode_and_sign(any, atom | String.t) :: {:ok, String.t, map} |
-                                                 {:error, atom} |
-                                                 {:error, String.t}
+                                                 {:error, any}
   def encode_and_sign(object, type), do: encode_and_sign(object, type, %{})
 
   @doc false
@@ -77,8 +75,7 @@ defmodule Guardian do
       )
   """
   @spec encode_and_sign(any, atom | String.t, map) :: {:ok, String.t, map} |
-                                                      {:error, atom} |
-                                                      {:error, String.t}
+                                                      {:error, any}
   def encode_and_sign(object, type, claims) do
     case build_claims(object, type, claims) do
       {:ok, claims_for_token} ->
@@ -119,6 +116,7 @@ defmodule Guardian do
   This function is less efficient that revoke!/2.
   If you have claims, you should use that.
   """
+  @spec revoke!(String.t, map) :: :ok | {:error, any}
   def revoke!(jwt, params \\ %{}) do
     case decode_and_verify(jwt, params) do
       {:ok, claims} -> revoke!(jwt, claims, params)
@@ -131,6 +129,7 @@ defmodule Guardian do
   This provides a hook to revoke.
   The logic for revocation of belongs in a Guardian.Hook.on_revoke
   """
+  @spec revoke!(String.t, map, map) :: :ok | {:error, any}
   def revoke!(jwt, claims, _params) do
     case Guardian.hooks_module.on_revoke(claims, jwt) do
       {:ok, _} -> :ok
@@ -206,8 +205,7 @@ defmodule Guardian do
   The old token wont be revoked after the exchange
   """
   @spec exchange(String.t, String.t, String.t) :: {:ok, String.t, Map} |
-                              {:error, atom} |
-                              {:error, String.t}
+                                                  {:error, any}
 
   def exchange(old_jwt, from_typ, to_typ) do
     case decode_and_verify(old_jwt) do
@@ -263,8 +261,7 @@ defmodule Guardian do
   Verify the given JWT. This will decode_and_verify via decode_and_verify/2
   """
   @spec decode_and_verify(String.t) :: {:ok, map} |
-                                       {:error, atom} |
-                                       {:error, String.t}
+                                       {:error, any}
   def decode_and_verify(jwt), do: decode_and_verify(jwt, %{})
 
 
@@ -272,7 +269,7 @@ defmodule Guardian do
   Verify the given JWT.
   """
   @spec decode_and_verify(String.t, map) :: {:ok, map} |
-                                            {:error, atom | String.t}
+                                            {:error, any}
   def decode_and_verify(jwt, params) do
     params = if verify_issuer?() do
       params

--- a/lib/guardian/hooks.ex
+++ b/lib/guardian/hooks.ex
@@ -31,14 +31,14 @@ defmodule Guardian.Hooks do
     resource :: term,
     type :: atom,
     claims :: map()
-  ) :: {:ok, {term, atom, map}} | {:error, atom | String.t}
+  ) :: {:ok, {term, atom, map}} | {:error, any}
 
   @callback after_encode_and_sign(
     resource :: term,
     type :: atom,
     claims :: map(),
     token :: String.t
-  ) :: {:ok, {term, atom, map, String.t}} | {:error, atom | String.t}
+  ) :: {:ok, {term, atom, map, String.t}} | {:error, any}
 
   @callback after_sign_in(
     conn :: Plug.Conn.t,
@@ -53,12 +53,12 @@ defmodule Guardian.Hooks do
   @callback on_verify(
     claims :: map(),
     jwt :: String.t
-  ) :: {:ok, {map(), String.t}} | {:error, atom | String.t}
+  ) :: {:ok, {map(), String.t}} | {:error, any}
 
   @callback on_revoke(
     claims :: map(),
     jwt :: String.t
-  ) :: {:ok, {map(), String.t}} | {:error, atom | String.t}
+  ) :: {:ok, {map(), String.t}} | {:error, any}
 end
 
 defmodule Guardian.Hooks.Default do

--- a/lib/guardian/hooks.ex
+++ b/lib/guardian/hooks.ex
@@ -31,14 +31,14 @@ defmodule Guardian.Hooks do
     resource :: term,
     type :: atom,
     claims :: map()
-  ) :: {:ok, {term, atom, map}}
+  ) :: {:ok, {term, atom, map}} | {:error, atom | String.t}
 
   @callback after_encode_and_sign(
     resource :: term,
     type :: atom,
     claims :: map(),
     token :: String.t
-  ) :: Plug.Conn.t
+  ) :: {:ok, {term, atom, map, String.t}} | {:error, atom | String.t}
 
   @callback after_sign_in(
     conn :: Plug.Conn.t,
@@ -53,12 +53,12 @@ defmodule Guardian.Hooks do
   @callback on_verify(
     claims :: map(),
     jwt :: String.t
-  ) :: {:ok, {map(), String.t}}
+  ) :: {:ok, {map(), String.t}} | {:error, atom | String.t}
 
   @callback on_revoke(
     claims :: map(),
     jwt :: String.t
-  ) :: {:ok, {map(), String.t}}
+  ) :: {:ok, {map(), String.t}} | {:error, atom | String.t}
 end
 
 defmodule Guardian.Hooks.Default do


### PR DESCRIPTION
This addresses https://github.com/ueberauth/guardian/issues/253. It includes https://github.com/ueberauth/guardian/pull/255, but I wasn't sure if I got the error types correct. 

I think the error type can be an atom or string. In GuardianDB, it looks like it's always an atom, but the typespec for methods that call the hooks allow both.

```
  @spec decode_and_verify(String.t, map) :: {:ok, map} |
                                            {:error, atom | String.t}

  @spec encode_and_sign(any, atom | String.t, map) :: {:ok, String.t, map} |
                                                      {:error, atom} |
                                                      {:error, String.t}
```

Guardian.Hooks.Test also returns strings, but I wrote that, so can fix it if it should be atoms... Did you want to keep it being both or only {:error, atom}?
