### PR TITLE
Accept binaries for ttl parameters

### DIFF
--- a/lib/guardian/claims.ex
+++ b/lib/guardian/claims.ex
@@ -103,6 +103,11 @@ defmodule Guardian.Claims do
   end
 
   @doc false
+  def ttl(the_claims, {num, period}) when is_binary(period) do
+    ttl(the_claims, {num, String.to_existing_atom(period)})
+  end
+
+  @doc false
   def ttl(%{"iat" => iat_v} = the_claims, requested_ttl) do
     assign_exp_from_ttl(the_claims, {iat_v, requested_ttl})
   end

--- a/lib/guardian/claims.ex
+++ b/lib/guardian/claims.ex
@@ -98,6 +98,11 @@ defmodule Guardian.Claims do
   end
 
   @doc false
+  def ttl(the_claims, {num, period}) when is_binary(num) do
+    ttl(the_claims, {String.to_integer(num), period})
+  end
+
+  @doc false
   def ttl(%{"iat" => iat_v} = the_claims, requested_ttl) do
     assign_exp_from_ttl(the_claims, {iat_v, requested_ttl})
   end

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -210,20 +210,20 @@ defmodule GuardianTest do
     assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
   end
 
-  test "encode_and_sign(object, aud) with ttl, number as binary" do
+  test "encode_and_sign(object, aud) with ttl, number and period as binaries" do
     {:ok, jwt, _} = Guardian.encode_and_sign(
       "thinger",
       "my_type",
-      ttl: {"5", :days}
+      ttl: {"5", "days"}
     )
 
     {:ok, claims} = Guardian.decode_and_verify(jwt)
     assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
   end
 
-  test "encode_and_sign(object, aud) with ttl in claims, number as binary" do
+  test "encode_and_sign(object, aud) with ttl in claims, number and period as binaries" do
     claims = Guardian.Claims.app_claims
-    |> Guardian.Claims.ttl({"5", :days})
+    |> Guardian.Claims.ttl({"5", "days"})
 
     {:ok, jwt, _} = Guardian.encode_and_sign("thinger", "my_type", claims)
 

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -210,6 +210,27 @@ defmodule GuardianTest do
     assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
   end
 
+  test "encode_and_sign(object, aud) with ttl, number as binary" do
+    {:ok, jwt, _} = Guardian.encode_and_sign(
+      "thinger",
+      "my_type",
+      ttl: {"5", :days}
+    )
+
+    {:ok, claims} = Guardian.decode_and_verify(jwt)
+    assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
+  end
+
+  test "encode_and_sign(object, aud) with ttl in claims, number as binary" do
+    claims = Guardian.Claims.app_claims
+    |> Guardian.Claims.ttl({"5", :days})
+
+    {:ok, jwt, _} = Guardian.encode_and_sign("thinger", "my_type", claims)
+
+    {:ok, claims} = Guardian.decode_and_verify(jwt)
+    assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
+  end
+
   test "encode_and_sign(object, aud) with exp and iat" do
     iat = Guardian.Utils.timestamp - 100
     exp = Guardian.Utils.timestamp + 100


### PR DESCRIPTION
Hello,
It would be interesting to accept binaries for ttl parameters :
```
{"5", "days"}
```
Now, only this form is accepted :
```
{5, :days}
```
Many other Elixir projects give this opportunity (Ecto, Phoenix...)
This is useful when you want to be able to change config at runtime : one of the available techniques only works with binary parameters, not atom nor integers... 