### PR TITLE
Allowing for phoenix rc releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Guardian.Mixfile do
 
   defp deps do
     [{:jose, "~> 1.8"},
-     {:phoenix, "~> 1.2.0", optional: true},
+     {:phoenix, "~> 1.2.0 or ~> 1.2-rc", optional: true},
      {:plug, "~> 1.0"},
      {:poison, ">= 1.3.0"},
      {:uuid, ">=1.1.1"},


### PR DESCRIPTION
Phoenix as at 1.3-rc right now and I can't install guardian with it. Doing `override: true` on this dependency did nothing, but adjusting version string made it install.

```
Failed to use "phoenix" (version 1.3.0-rc.0) because
  guardian (versions 0.14.0 to 0.14.2) requires ~> 1.2.0
```