### PR TITLE
Add ability to set claim to look for in LoadResource

### DIFF
--- a/lib/guardian/plug/load_resource.ex
+++ b/lib/guardian/plug/load_resource.ex
@@ -18,6 +18,8 @@ defmodule Guardian.Plug.LoadResource do
     * `:serializer` - The serializer to use to load the current resource from
         the subject claim of the token. Defaults to the result of
         `Guardian.serializer/0`.
+
+    * `:claim` - The claim to look for to pass value to serializer. Defaults to `sub`.
   """
 
   @doc false
@@ -48,8 +50,9 @@ defmodule Guardian.Plug.LoadResource do
 
   defp load_resource(claims, opts) do
     serializer = get_serializer(opts)
+    resource_claim = Map.get(opts, :claim, "sub")
 
-    claims |> Map.get("sub") |> serializer.from_token
+    claims |> Map.get(resource_claim) |> serializer.from_token
   end
 
   defp get_serializer(opts) do

--- a/lib/guardian/plug/load_resource.ex
+++ b/lib/guardian/plug/load_resource.ex
@@ -52,7 +52,9 @@ defmodule Guardian.Plug.LoadResource do
     serializer = get_serializer(opts)
     resource_claim = Map.get(opts, :claim, "sub")
 
-    claims |> Map.get(resource_claim) |> serializer.from_token
+    claims
+    |> Map.get(resource_claim)
+    |> serializer.from_token()
   end
 
   defp get_serializer(opts) do

--- a/test/guardian/plug/load_resource_test.exs
+++ b/test/guardian/plug/load_resource_test.exs
@@ -55,4 +55,25 @@ defmodule Guardian.Plug.LoadResourceTest do
     |> run_plug(LoadResource, serializer: TestSerializer)
     assert Guardian.Plug.current_resource(conn) == "42"
   end
+
+  test "claim option specified, but not found", %{conn: conn} do
+    sub =  "User:42"
+
+    conn = conn
+    |> Guardian.Plug.set_claims({:ok, %{"sub" => sub}})
+    |> run_plug(LoadResource, claim: "user")
+
+    assert Guardian.Plug.current_resource(conn) == nil
+  end
+
+  test "claim option specified, and is found", %{conn: conn} do
+    sub =  "User:42"
+
+    conn = conn
+    |> Guardian.Plug.set_claims({:ok, %{"user" => sub}})
+    |> run_plug(LoadResource, claim: "user")
+
+    {:ok, resource} = Guardian.serializer.from_token(sub)
+    assert Guardian.Plug.current_resource(conn) == resource
+  end
 end


### PR DESCRIPTION
fixes #268 

Adds `claim` option to `Guardian.Plug.LoadResource` in order to specify claim to use when looking for value to pass to serializer