### PR TITLE
Move configuration checks to runtime

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -313,7 +313,8 @@ defmodule Guardian do
 
   @doc false
   def config do
-    Application.get_env(:guardian, Guardian)
+    :guardian
+    |> Application.get_env(Guardian)
     |> check_config
   end
 

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -22,14 +22,6 @@ defmodule Guardian do
   @default_algos ["HS512"]
   @default_token_type "access"
 
-  unless Application.get_env(:guardian, Guardian) do
-    raise "Guardian is not configured"
-  end
-
-  unless Keyword.get(Application.get_env(:guardian, Guardian), :serializer) do
-    raise "Guardian requires a serializer"
-  end
-
   @doc """
   Returns the current default token type.
   """
@@ -320,7 +312,20 @@ defmodule Guardian do
   defp verify_issuer?, do: config(:verify_issuer, false)
 
   @doc false
-  def config, do: Application.get_env(:guardian, Guardian)
+  def config do
+    Application.get_env(:guardian, Guardian)
+    |> check_config
+  end
+
+  @doc false
+  def check_config(nil), do: raise "Guardian is not configured"
+  def check_config(cfg) do
+    case Keyword.has_key?(cfg, :serializer) do
+      false -> raise "Guardian requires a serializer"
+      true  -> cfg
+    end
+  end
+
   @doc false
   def config(key, default \\ nil),
     do: config() |> Keyword.get(key, default) |> resolve_config(default)

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -48,6 +48,20 @@ defmodule GuardianTest do
     }
   end
 
+  test "no config" do
+    cfg = Guardian.config
+    Application.put_env(:guardian, Guardian, nil)
+    assert_raise RuntimeError, "Guardian is not configured", &Guardian.config/0
+    Application.put_env(:guardian, Guardian, cfg)
+  end
+
+  test "config with no serializer" do
+    cfg = Guardian.config
+    Application.put_env(:guardian, Guardian, Keyword.drop(cfg, [:serializer]))
+    assert_raise RuntimeError, "Guardian requires a serializer", &Guardian.config/0
+    Application.put_env(:guardian, Guardian, cfg)
+  end
+
   test "config with a value" do
     assert Guardian.config(:issuer) == "MyApp"
   end


### PR DESCRIPTION
Guardian was checking for its configuration and serializer at compile-time, which is a problem when compiling in an environment without a configuration. Permissions were moved to runtime fetching in #88, and I propose we move the configuration check there as well.

As an example of when a situation like this might occur, I was trying to speed up a Docker build by caching the compiled dependencies, using only `mix.exs` and `mix.lock`. Our configuration changes more often than our dependencies, so I do not include the config files for that cache step else any config change will force a recompile of all dependencies. Hope that makes sense.