### PR TITLE
#288 Allow people to use guardian with phoenix 1.3.0-rc.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Guardian.Mixfile do
 
   defp deps do
     [{:jose, "~> 1.8"},
-     {:phoenix, "~> 1.2", optional: true},
+     {:phoenix, ">= 1.2.0-rc1", optional: true},
      {:plug, "~> 1.3"},
      {:poison, ">= 1.3.0"},
      {:uuid, ">=1.1.1"},


### PR DESCRIPTION
Version 1.2 is still supported and remains the default.