### PR TITLE
support a simple session without JWT

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -401,7 +401,7 @@ defmodule Guardian do
 
   defp verify_claims(claims, [], _, _), do: {:ok, claims}
 
-  defp build_claims(object, type, claims) do
+  def build_claims(object, type, claims) do
     case Guardian.serializer.for_token(object) do
       {:ok, sub} ->
         full_claims = claims

--- a/lib/guardian/plug/verify_claims.ex
+++ b/lib/guardian/plug/verify_claims.ex
@@ -1,0 +1,83 @@
+defmodule Guardian.Plug.VerifyClaims do
+  @moduledoc """
+  Use this plug to verify and load claims contained in a session.
+
+  ## Example
+
+      plug Guardian.Plug.VerifyClaims
+
+  You can also specify a location to look for the claims
+
+  ## Example
+
+      plug Guardian.Plug.VerifyClaims, key: :secret
+
+  Loading the claims will make them available on the connecion, available
+  with Guardian.Plug.claims/1
+
+  In the case of an error, the claims will be set to { :error, reason }
+  """
+  import Guardian.Keys
+  import Guardian.Utils
+
+  @doc false
+  def init(opts \\ %{}), do: Enum.into(opts, %{})
+
+  @doc false
+  def call(conn, opts) do
+    key = Map.get(opts, :key, :default)
+
+    case Guardian.Plug.claims(conn, key) do
+      {:ok, _} -> conn
+      {:error, _} ->
+        claims = Plug.Conn.get_session(conn, base_key(key))
+
+        if claims do
+          case decode_and_verify(claims, %{}) do
+            {:ok, claims} ->
+              conn
+              |> Guardian.Plug.set_claims({:ok, claims}, key)
+            {:error, reason} ->
+              conn
+              |> Plug.Conn.delete_session(base_key(key))
+              |> Guardian.Plug.set_claims({:error, reason}, key)
+          end
+        else
+          conn
+        end
+    end
+  end
+
+  @doc """
+  Verify the given claims. This will decode_and_verify via decode_and_verify/2
+  """
+  @spec decode_and_verify(map) :: {:ok, map} |
+                                       {:error, any}
+  def decode_and_verify(claims), do: decode_and_verify(claims, %{})
+
+  @doc """
+  Verify the given claims.
+  """
+  @spec decode_and_verify(map, map) :: {:ok, map} | {:error, any}
+  def decode_and_verify(claims, params) do
+    params = if verify_issuer?() do
+      params
+      |> stringify_keys
+      |> Map.put_new("iss", Guardian.issuer())
+    else
+      params
+    end
+    params = stringify_keys(params)
+
+    # try do
+      with {:ok, verified_claims} <- Guardian.verify_claims(claims, params),
+           {:ok, {claims, _}} <- Guardian.hooks_module.on_verify(verified_claims, nil),
+        do: {:ok, claims}
+    # rescue
+    #   e ->
+    #     {:error, e}
+    # end
+  end
+
+  defp verify_issuer?, do: Guardian.config(:verify_issuer, false)
+end

--- a/test/guardian/plug/verify_claims_test.exs
+++ b/test/guardian/plug/verify_claims_test.exs
@@ -1,0 +1,60 @@
+defmodule Guardian.Plug.VerifyClaimsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use Plug.Test
+  import Guardian.TestHelper
+
+  alias Guardian.Plug.VerifyClaims
+
+  setup do
+    conn = conn_with_fetched_session(conn(:get, "/"))
+    claims = Guardian.Claims.app_claims(%{"sub" => "user", "aud" => "aud"})
+
+    {
+      :ok,
+      conn: conn,
+      claims: claims,
+    }
+  end
+
+  test "with no Claims in the session at a default location", context do
+    conn = run_plug(context.conn, VerifyClaims)
+    assert Guardian.Plug.claims(conn) == {:error, :no_session}
+    assert Guardian.Plug.current_token(conn) == nil
+  end
+
+  test "with no Claims in the session at a specified location", context do
+    conn = run_plug(context.conn, VerifyClaims, %{key: :secret})
+    assert Guardian.Plug.claims(conn, :secret) == {:error, :no_session}
+    assert Guardian.Plug.current_token(conn, :secret) == nil
+  end
+
+  test "with valid Claims in the session at the default location", context do
+    conn =
+      context.conn
+      |> Plug.Conn.put_session(Guardian.Keys.base_key(:default), context.claims)
+      |> run_plug(VerifyClaims)
+
+    assert Guardian.Plug.claims(conn) == {:ok, context.claims}
+  end
+
+  test "with valid Claims in the session at a specified location", context do
+    conn =
+      context.conn
+      |> Plug.Conn.put_session(Guardian.Keys.base_key(:secret), context.claims)
+      |> run_plug(VerifyClaims, %{key: :secret})
+
+    assert Guardian.Plug.claims(conn, :secret) == {:ok, context.claims}
+  end
+
+  test "with an existing session in another location", context do
+    conn =
+      context.conn
+      |> Plug.Conn.put_session(Guardian.Keys.base_key(:default), context.claims)
+      |> Guardian.Plug.set_claims(context.claims)
+      |> Plug.Conn.put_session(Guardian.Keys.base_key(:secret), context.claims)
+      |> run_plug(VerifyClaims, %{key: :secret})
+
+    assert Guardian.Plug.claims(conn, :secret) == {:ok, context.claims}
+  end
+end

--- a/test/integration/claims_auth_test.exs
+++ b/test/integration/claims_auth_test.exs
@@ -1,0 +1,35 @@
+defmodule Guardian.Integration.ClaimsAuthTest do
+  @moduledoc false
+  use ExUnit.Case
+  use Plug.Test
+
+  import Guardian.TestHelper
+
+  alias Guardian.Plug.LoadResource
+  alias Guardian.Plug.VerifyClaims
+  alias Guardian.Claims
+
+  defmodule TestSerializer do
+    @moduledoc false
+    @behaviour Guardian.Serializer
+
+    def from_token("Company:" <> id), do: {:ok, id}
+    def for_token(_), do: {:ok, nil}
+  end
+
+  test "load current resource with a valid jwt in session" do
+    claims = Claims.app_claims(%{"sub" => "Company:42", "aud" => "aud"})
+
+    conn = conn(:get, "/")
+
+    conn =
+      conn
+      |> conn_with_fetched_session
+      |> put_session(Guardian.Keys.base_key(:default), claims)
+      |> run_plug(VerifyClaims)
+      |> run_plug(LoadResource, serializer: TestSerializer)
+
+    assert Guardian.Plug.current_resource(conn) == "42"
+    assert Guardian.Plug.claims(conn) == {:ok, claims}
+  end
+end


### PR DESCRIPTION
Similar to https://github.com/ueberauth/guardian/pull/297, I've been thinking about something like guardian, but without any tokens. For a simple session JWT is pretty heavyweight. I really like the common set of methods, but this might be too far out of Guardians use case. I basically just store the claims in the session and let Plug handle the security. Then there's a plug to load those claims into the private claims. This won't work for all cases (API, Channels, others?), but I think there's a use case for something that provides a simple serializer for storing a serialized resource and permissions in the session.