### PR TITLE
adjust variable names

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -66,8 +66,8 @@ defmodule Guardian.Plug do
   A simple check to see if a request is authenticated
   """
   @spec authenticated?(Plug.Conn.t, atom) :: atom # boolean
-  def authenticated?(conn, type) do
-    case claims(conn, type) do
+  def authenticated?(conn, the_key) do
+    case claims(conn, the_key) do
       {:error, _} -> false
       _ -> true
     end

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -174,7 +174,7 @@ defmodule GuardianTest do
     assert claims["iss"] == Guardian.issuer
   end
 
-  test "encode_and_sign(object, audience)" do
+  test "encode_and_sign(object, type)" do
     {:ok, jwt, _} = Guardian.encode_and_sign("thinger", "my_type")
 
     {:ok, claims} = Guardian.decode_and_verify(jwt)
@@ -203,7 +203,7 @@ defmodule GuardianTest do
     assert claims["some"] == "thing"
   end
 
-  test "encode_and_sign(object, aud) with ttl" do
+  test "encode_and_sign(object, type) with ttl" do
     {:ok, jwt, _} = Guardian.encode_and_sign(
       "thinger",
       "my_type",
@@ -214,7 +214,7 @@ defmodule GuardianTest do
     assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
   end
 
-  test "encode_and_sign(object, aud) with ttl in claims" do
+  test "encode_and_sign(object, type) with ttl in claims" do
     claims = Guardian.Claims.app_claims
     |> Guardian.Claims.ttl({5, :days})
 
@@ -224,7 +224,7 @@ defmodule GuardianTest do
     assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
   end
 
-  test "encode_and_sign(object, aud) with ttl, number and period as binaries" do
+  test "encode_and_sign(object, type) with ttl, number and period as binaries" do
     {:ok, jwt, _} = Guardian.encode_and_sign(
       "thinger",
       "my_type",
@@ -235,7 +235,7 @@ defmodule GuardianTest do
     assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
   end
 
-  test "encode_and_sign(object, aud) with ttl in claims, number and period as binaries" do
+  test "encode_and_sign(object, type) with ttl in claims, number and period as binaries" do
     claims = Guardian.Claims.app_claims
     |> Guardian.Claims.ttl({"5", "days"})
 
@@ -245,7 +245,7 @@ defmodule GuardianTest do
     assert claims["exp"] == claims["iat"] + 5 * 24 * 60 * 60
   end
 
-  test "encode_and_sign(object, aud) with exp and iat" do
+  test "encode_and_sign(object, type) with exp and iat" do
     iat = Guardian.Utils.timestamp - 100
     exp = Guardian.Utils.timestamp + 100
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,8 +4,8 @@ defmodule Guardian.TestGuardianSerializer do
   @behaviour Guardian.Serializer
   def for_token(%{error: :unknown}), do: {:error, "Unknown resource type"}
 
-  def for_token(aud), do: {:ok, aud}
-  def from_token(aud), do: {:ok, aud}
+  def for_token(sub), do: {:ok, sub}
+  def from_token(sub), do: {:ok, sub}
 end
 
 defmodule Guardian.TestHelper do


### PR DESCRIPTION
The method signature was the same in all these cases, but the variable were named differently. None of them were negatively impacting the code.