### PR TITLE
Add permissions for v1

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,8 +3,9 @@ use Mix.Config
 
 config :phoenix, format_encoders: [json: Poison]
 
-config :guardian, GuardianPhoenix.ControllerTest.Endpoint,
+config :guardian, Guardian.Phoenix.ControllerTest.Endpoint,
   secret_key_base: "lksdjfl"
 
-config :guardian, GuardianPhoenix.SocketTest.Impl,
-  stuff: "and things"
+config :guardian, Guardian.Phoenix.SocketTest.Impl, []
+
+config :guardian, Guardian.Phoenix.Permissions.BitwiseTest.Impl, []

--- a/lib/guardian/permissions/bitwise.ex
+++ b/lib/guardian/permissions/bitwise.ex
@@ -1,0 +1,443 @@
+defmodule Guardian.Permissions.Bitwise do
+  @moduledoc """
+  An optional plugin to Guardian to provide permissions for your tokens
+
+  These can be used for any token types since they only work on the `claims`.
+
+  Permissions are set on a per implementation module basis.
+  Each implementation module can have their own sets.
+  Permissions are similar in concept to OAuth2 scopes. They're encoded into a token
+  and the permissions granted last as long as the token does.
+  This makes it unsuitable for highly dynamic permission schemes.
+  They're best left to an application to implement.
+
+  For example. (at the time of writing) some of the Facebook permissions are:
+
+  * public_profile
+  * user_about_me
+  * user_actions.books
+  * user_actions.fitness
+  * user_actions.music
+
+  To create permissions for your application similar to these:
+
+  ```elixir
+  defmodule MyApp.Auth.Token do
+
+    use Guardian, otp_app: :my_app,
+                           permissions: %{
+                           default: [:public_profile, :user_about_me]
+                           user_actions: %{
+                             books: 0b1,
+                             fitness: 0b100,
+                             music: 0b1000,
+                           }
+                         }
+
+    use Guardian.Permissions.Bitwise
+
+    # snip
+
+    def build_claims(claims, _resource, opts) do
+      claims
+      |> encode_permissions_into_claims!(Keyword.get(opts, :permissions))
+    end
+  end
+  ```
+
+  This will take the permission set in the `opts` at `:permissions` and
+  put it into the `"pems"` key of the claims as a map of:
+  `%{set_name => integer}`
+
+  The permissions can be defined as a list (positional value based on index)
+  or a map where the value for each permission is manually provided.
+
+  They can be provided either as options to `use Guardian` or in the config for
+  your implementation module.
+
+  Once you have a token, you can interact with it.
+
+  ```elixir
+  # Get the encoded permissions from the claims
+  found_perms = MyApp.Auth.Token.decode_permissions_from_claims(claims)
+
+  # Check if all permissions are present
+  has_all_these_things? =
+    claims
+    |> MyApp.Auth.Token.decode_permissions_from_claims(claims)
+    |> MyApp.Auth.Token.all_permissions?(%{default: [:user_about_me, :public_profile]})
+
+  # Checks if any permissions are present
+  show_any_media_things? =
+    claims
+    |> MyApp.Auth.Token.decode_permissions_from_claims(claims)
+    |> MyApp.Auth.Token.any_permissions?(%{user_actions: [:books, :fitness, :music]})
+  ```
+
+  ### Using with Plug
+
+  To use a plug for ensuring permissions you can use the `Guardian.Permissions.Bitwise` module as part of a
+  Guardian pipeline.
+
+  ```elixir
+  # After a pipeline has setup the implementation module and error handler
+
+  # Ensure that both the `public_profile` and `user_actions.books` permissions are present in the token
+  plug Guardian.Permissions.Bitwise, ensure: %{default: [:public_profile], user_actions: [:books]}
+
+  # Allow the request to continue when the token contains any of the permission sets specified
+  plug Guardian.Permissions.Bitwise, one_of: [
+    %{default: [:public_profile], user_actions: [:books]},
+    %{default: [:public_profile], user_actions: [:music]},
+  ]
+
+  # Look for permissions for a token in a different location
+  plug Guardian.Permissions.Bitwise, key: :impersonate, ensure: %{default: [:public_profile]}
+  ```
+
+  If the token satisfies either the permissions listed in `ensure` or one of the sets in the `one_of` key
+  the request will continue. If not, then `auth_error` callback will be called on the error handler with
+  `auth_error(conn, {:unauthorized, reason}, options)`
+  """
+
+  @type label :: atom
+  @type permission_set :: %{optional(label) => pos_integer}
+  @type t :: %{optional(label) => permission_set}
+
+  @type input_label :: String.t :: atom
+  @type input_set :: [input_label, ...] | pos_integer
+  @type input_permissions :: %{optional(input_label) => input_set}
+
+  @type plug_option :: {:ensure, permission_set} |
+                       {:one_of, [permission_set, ...]} |
+                       {:key, atom} |
+                       {:module, Guardian.t} |
+                       {:error_handler, module}
+
+  defmodule PermissionNotFoundError do
+    defexception [:message]
+  end
+
+  alias Guardian.Plug, as: GPlug
+  alias GPlug.Pipeline
+
+  defmacro __using__(_opts \\ []) do
+    # Credo is incorrectly identifying an unless block with negated condition 2017-06-10
+    # credo:disable-for-next-line /\.Refactor\./
+    quote do
+      use Bitwise
+
+      alias Guardian.Permissions.Bitwise, as: GBits
+      alias GBits.PermissionNotFoundError
+
+      defdelegate max(), to: Guardian.Permissions.Bitwise
+
+      raw_perms = @config_with_key.(:permissions)
+
+      unless raw_perms do
+        raise "Permissions are not defined for #{to_string(__MODULE__)}"
+      end
+
+      @normalized_perms GBits.normalize_permissions(raw_perms)
+      @available_permissions GBits.available_from_normalized(@normalized_perms)
+
+      @doc """
+      Lists all permissions in a normalized way using %{permission_set_name => [permission_name, ...]}
+      """
+
+      @spec available_permissions() :: GBits.t
+      def available_permissions, do: @available_permissions
+
+      @doc """
+      Decodes permissions from the permissions found in claims (encoded to integers) or
+      from a list of permissions.
+
+         iex> MyTokens.decode_permissions(%{default: [:public_profile]})
+         %{default: [:public_profile]}
+
+         iex> MyTokens.decode_permissions{%{"default" => 1, "user_actions" => 1}}
+         %{default: [:public_profile], user_actions: [:books]}
+
+      When using integers (after encoding to claims), unknown bit positions are ignored.
+
+          iex> MyTokens.decode_permissions(%{"default" => -1})
+          %{default: [:public_profile, :user_about_me]}
+      """
+      @spec decode_permissions(GBits.input_permissions | nil) :: GBits.t
+      def decode_permissions(nil), do: %{}
+      def decode_permissions(map) when is_map(map) do
+        for {k, v} <- map,
+            Map.get(@normalized_perms, to_string(k)) != nil,
+            into: %{} do
+          key = k |> to_string() |> String.to_atom()
+          {key, do_decode_permissions(v, k)}
+        end
+      end
+
+      @doc """
+      Decodes permissions directly from a claims map. This does the same as `decode_permissions` but
+      will fetch the permissions map from the `"pem"` key where `Guardian.Permissions.Bitwise` places them
+      when it encodes them into claims.
+      """
+      @spec decode_permissions_from_claims(Guardian.Token.claims) :: GBits.t
+      def decode_permissions_from_claims(%{"pem" => perms}),
+        do: decode_permissions(perms)
+      def decode_permissions_from_claims(_), do: %{}
+
+      @doc """
+      Encodes the permissions provided into the claims in the `"pem"` key.
+      Permissions are encoded into an integer inside the token corresponding
+      with the value provided in the configuration.
+      """
+      @spec encode_permissions_into_claims!(
+        Guardian.Token.claims, GBits.input_permissions | nil
+      ) :: Guardian.Token.claims
+      def encode_permissions_into_claims!(claims, nil), do: claims
+      def encode_permissions_into_claims!(claims, perms) do
+        encoded_perms = encode_permissions!(perms)
+        Map.put(claims, "pem", encoded_perms)
+      end
+
+      @doc """
+      Checks to see if any of the permissions provided are present
+      in the permissions (previously extracted from claims)
+
+      iex> claims |> MyTokens.decode_permissions() |> any_permissions?(%{user_actions: [:books, :music]})
+      true
+      """
+      @spec any_permissions?(GBits.input_permissions, GBits.input_permissions) :: boolean
+      def any_permissions?(has_perms, test_perms) when is_map(test_perms) do
+        has_perms = decode_permissions(has_perms)
+        test_perms = decode_permissions(test_perms)
+        Enum.any? test_perms, fn {k, needs} ->
+          has_perms |> Map.get(k) |> do_any_permissions?(MapSet.new(needs))
+        end
+      end
+
+      defp do_any_permissions?(nil, %MapSet{}), do: false
+      defp do_any_permissions?(list, %MapSet{} = needs) do
+        matches = needs |> MapSet.intersection(MapSet.new(list))
+        matches > 0
+      end
+
+      @doc """
+      Checks to see if all of the permissions provided are present
+      in the permissions (previously extracted from claims)
+
+      iex> claims |> MyTokens.decode_permissions() |> all_permissions?(%{user_actions: [:books, :music]})
+      true
+      """
+      @spec all_permissions?(GBits.input_permissions, GBits.input_permissions) :: boolean
+      def all_permissions?(has_perms, test_perms) when is_map(test_perms) do
+        has_perms = decode_permissions(has_perms)
+        test_perms = decode_permissions(test_perms)
+
+        Enum.all? test_perms, fn {k, needs} ->
+          has = has_perms |> Map.get(k, []) |> Enum.sort()
+          wants = Enum.sort(needs)
+
+          case [has, wants] do
+            [same, same] -> true
+            _ -> false
+          end
+        end
+      end
+
+      @doc """
+      Encodes the permissions provided into numeric form
+
+      iex> MyTokens.encode_permissions!(%{user_actions: [:books, :music]})
+      %{user_actions: 9}
+      """
+      @spec encode_permissions!(GBits.input_permissions | nil) :: GBits.t
+      def encode_permissions!(nil), do: %{}
+      def encode_permissions!(map) when is_map(map) do
+        for {k, v} <- map, into: %{} do
+          key = String.to_atom(to_string(k))
+          {key, do_encode_permissions!(v, k)}
+        end
+      end
+
+      @doc """
+      Validates that all permissions provided exist in the configuration.
+
+      iex> MyTokens.validate_permissions!(%{default: [:user_about_me]})
+
+      iex> MyTokens.validate_permissions!(%{not: [:a, :thing]})
+      raise Guardian.Permissions.Bitwise.PermissionNotFoundError
+      """
+      def validate_permissions!(map) when is_map(map) do
+        Enum.all?(&do_validate_permissions!/1)
+      end
+
+      defp do_decode_permissions(other), do: do_decode_permissions(other, "default")
+      defp do_decode_permissions(value, type) when is_atom(type),
+        do: do_decode_permissions(value, to_string(type))
+
+      defp do_decode_permissions(value, type) when is_list(value) do
+        do_validate_permissions!({type, value})
+        value |> Enum.map(&to_string/1) |> Enum.map(&String.to_atom/1)
+      end
+
+      defp do_decode_permissions(value, type) when is_integer(value) do
+        perms = Map.get(@normalized_perms, type)
+        for {k, v} <- perms,
+            band(value, v) == v,
+            into: [] do
+          k |> to_string() |> String.to_atom()
+        end
+      end
+
+      defp do_encode_permissions!(value, type) when is_atom(type),
+        do: do_encode_permissions!(value, to_string(type))
+
+      defp do_encode_permissions!(value, _type) when is_integer(value), do: value
+
+      defp do_encode_permissions!(value, type) when is_list(value) do
+        do_validate_permissions!({type, value})
+        perms = Map.get(@normalized_perms, type)
+        Enum.reduce(value, 0, &encode_value(&1, perms, &2))
+      end
+
+      defp encode_value(value, perm_set, acc),
+        do: perm_set |> Map.get(to_string(value)) |> bor(acc)
+
+      defp do_validate_permissions!({type, value}) when is_atom(type),
+        do: do_validate_permissions!({to_string(type), value})
+
+      defp do_validate_permissions!({type, map}) when is_map(map) do
+        list = map |> Map.keys(map) |> Enum.map(&to_string/1)
+        do_validate_permissions!({type, list})
+      end
+
+      defp do_validate_permissions!({type, list}) do
+        perm_set = Map.get(@normalized_perms, type)
+
+        if perm_set do
+          provided_set = list |> Enum.map(&to_string/1) |> MapSet.new()
+          known_set = perm_set |> Map.keys() |> MapSet.new()
+
+          diff = MapSet.difference(provided_set, known_set)
+          if MapSet.size(diff) > 0 do
+            message = "#{to_string(__MODULE__)} Type: #{type} Missing Permissions: #{Enum.join(diff, ", ")}"
+            raise PermissionNotFoundError, message: message
+          end
+          :ok
+        else
+          raise PermissionNotFoundError, message: "#{to_string(__MODULE__)} - Type: #{type}"
+        end
+      end
+    end
+  end
+
+  @doc """
+  Provides an encoded version of all permissions, and all possible future permissions
+  for a permission set
+  """
+  def max, do: -1
+
+  @doc false
+  def normalize_permissions(perms) do
+    perms = Enum.into(perms, %{})
+    for {k, v} <- perms, into: %{} do
+      case v do
+        # A list of permission names.
+        # Positional values
+        list when is_list(list) ->
+          perms =
+            for {perm, idx} <- Enum.with_index(list), into: %{} do
+              {to_string(perm), trunc(:math.pow(2, idx))}
+            end
+          {to_string(k), perms}
+
+        # A map of permissions. The permissions should be name => bit value
+        map when is_map(map) ->
+          perms = for {perm, val} <- map, into: %{}, do: {to_string(perm), val}
+          {to_string(k), perms}
+      end
+    end
+  end
+
+  @doc false
+  def available_from_normalized(perms) do
+    for {k, v} <- perms, into: %{} do
+      list = v |> Map.keys() |> Enum.map(&String.to_atom/1)
+      {String.to_atom(k), list}
+    end
+  end
+
+  if Code.ensure_loaded?(Plug) do
+    import Plug.Conn
+
+    @doc false
+    @spec init([plug_option]) :: [plug_option]
+    def init(opts) do
+      ensure = Keyword.get(opts, :ensure)
+      one_of = Keyword.get(opts, :one_of)
+      if ensure && one_of do
+        raise ":permissions and a :one_of cannot both be specified for plug #{to_string __MODULE__} "
+      end
+
+      opts =
+        if Keyword.keyword?(ensure) do
+          ensure = ensure |> Enum.into(%{})
+          Keyword.put(opts, :ensure, ensure)
+        else
+          opts
+        end
+
+      opts
+    end
+
+    @doc false
+    @spec call(Plug.Conn.t, [plug_option]) :: Plug.Conn.t
+    def call(conn, opts) do
+      context = %{
+        claims: GPlug.current_claims(conn, opts),
+        ensure: Keyword.get(opts, :ensure),
+        handler: Pipeline.fetch_error_handler!(conn, opts),
+        impl: Pipeline.fetch_module!(conn, opts),
+        one_of: Keyword.get(opts, :one_of)
+      }
+      do_call(conn, context, opts)
+    end
+
+    defp do_call(conn, %{ensure: nil, one_of: nil}, _), do: conn
+    defp do_call(conn, %{claims: nil} = ctx, opts) do
+      ctx.handler
+      |> apply(:auth_error, [conn, {:unauthorized, :unauthorized}, opts])
+      |> halt()
+    end
+
+    # single set of permissions to check
+    defp do_call(conn, %{one_of: nil} = ctx, opts) do
+      has_perms = apply(ctx.impl, :decode_permissions_from_claims, [ctx.claims])
+      is_ok? = apply(ctx.impl, :all_permissions?, [has_perms, ctx.ensure])
+
+      if is_ok? do
+        conn
+      else
+        ctx.handler
+        |> apply(:auth_error, [conn, {:unauthorized, :unauthorized}, opts])
+        |> halt()
+      end
+    end
+
+    # one_of sets of permissions to check
+    defp do_call(conn, %{ensure: nil} = ctx, opts) do
+      has_perms = apply(ctx.impl, :decode_permissions_from_claims, [ctx.claims])
+      is_ok? =
+        Enum.any? ctx.one_of, fn test_perms ->
+          apply(ctx.impl, :all_permissions?, [has_perms, test_perms])
+        end
+
+      if is_ok? do
+        conn
+      else
+        ctx.handler
+        |> apply(:auth_error, [conn, {:unauthorized, :unauthorized}, opts])
+        |> halt()
+      end
+    end
+  end
+end

--- a/test/guardian/permissions/bitwise_test.exs
+++ b/test/guardian/permissions/bitwise_test.exs
@@ -1,0 +1,298 @@
+defmodule Guardian.Permissions.BitwiseTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+
+  alias Guardian.Plug, as: GPlug
+  alias GPlug.Pipeline
+  alias Guardian.Permissions.Bitwise, as: GBits
+
+  defmodule Impl do
+    use Guardian, otp_app: :guardian,
+                  permissions: %{
+                    user: [:read, :write],
+                    profile: %{read: 0b1, write: 0b10}
+                  },
+                  token_module: Guardian.Support.TokenModule
+
+    use Guardian.Permissions.Bitwise
+
+    def subject_for_token(resource, _claims), do: {:ok, resource}
+    def resource_from_claims(claims), do: {:ok, claims["sub"]}
+
+    def build_claims(claims, _resource, opts) do
+      claims
+      |> encode_permissions_into_claims!(Keyword.get(opts, :permissions))
+    end
+  end
+
+  defmodule Handler do
+    @moduledoc false
+
+    import Plug.Conn
+
+    def auth_error(conn, {type, reason}, _opts) do
+      body = inspect({type, reason})
+      send_resp(conn, 403, body)
+    end
+  end
+
+  test "max is -1" do
+    assert __MODULE__.Impl.max == -1
+  end
+
+  describe "normalize_permissions" do
+    test "it normalizes a list of permissions" do
+      result = GBits.normalize_permissions(%{some: [:read, :write], other: [:one, :two]})
+      assert result == %{
+        "some" => %{"read" => 0b1, "write" => 0b10},
+        "other" => %{"one" => 0b1, "two" => 0b10},
+      }
+    end
+
+    test "it normalizes a map of permissions" do
+      perms = %{
+        some: %{read: 0b1, write: 0b10},
+        other: %{"one" => 0b1, "two" => 0b10},
+      }
+
+      result = GBits.normalize_permissions(perms)
+      assert result == %{
+        "some" => %{"read" => 0b1, "write" => 0b10},
+        "other" => %{"one" => 0b1, "two" => 0b10},
+      }
+    end
+
+    test "it normalizes a mix" do
+      perms = %{
+        some: %{read: 0b1, write: 0b10},
+        other: [:one, "two"],
+      }
+      result = GBits.normalize_permissions(perms)
+      assert result == %{
+        "some" => %{"read" => 0b1, "write" => 0b10},
+        "other" => %{"one" => 0b1, "two" => 0b10},
+      }
+    end
+  end
+
+  describe "available_permissions" do
+    test "it provides all the permissions" do
+      result = __MODULE__.Impl.available_permissions()
+      assert result == %{profile: [:read, :write], user: [:read, :write]}
+    end
+  end
+
+  describe "encode_permissions" do
+    test "it encodes to an empty map when there are no permissions given" do
+      %{} = result = __MODULE__.Impl.encode_permissions!(%{})
+      assert Enum.empty?(result)
+    end
+
+    test "it encodes when provided with an atom map" do
+      perms = %{profile: [:read, :write], user: [:read]}
+      result = __MODULE__.Impl.encode_permissions!(perms)
+      assert result == %{profile: 0b11, user: 0b1}
+    end
+
+    test "it encodes when provided with a string map" do
+      perms = %{"profile" => ["read", "write"], "user" => ["read"]}
+      result = __MODULE__.Impl.encode_permissions!(perms)
+      assert result == %{profile: 0b11, user: 0b1}
+    end
+
+    test "it encodes when provided with an integer" do
+      perms = %{profile: [], user: 0b1}
+      result = __MODULE__.Impl.encode_permissions!(perms)
+      assert result == %{profile: 0, user: 0b1}
+    end
+
+    test "it is ok with using max permissions" do
+      perms = %{profile: __MODULE__.Impl.max, user: 0b1}
+      result = __MODULE__.Impl.encode_permissions!(perms)
+      assert result == %{profile: -1, user: 0b1}
+    end
+
+    test "when setting from an integer it does not lose resolution" do
+      perms = %{profile: __MODULE__.Impl.max, user: 0b111111}
+      result = __MODULE__.Impl.encode_permissions!(perms)
+      assert result == %{profile: -1, user: 0b111111}
+    end
+
+    test "it raises on unknown permission set" do
+      msg = "#{to_string __MODULE__.Impl} - Type: not_a_thing"
+      assert_raise GBits.PermissionNotFoundError, msg, fn ->
+        perms = %{not_a_thing: [:not_a_thing]}
+        __MODULE__.Impl.encode_permissions!(perms)
+      end
+    end
+
+    test "it raises on unknown permissions" do
+      assert_raise GBits.PermissionNotFoundError, fn ->
+        perms = %{profile: [:wot, :now, :brown, :cow]}
+        __MODULE__.Impl.encode_permissions!(perms)
+      end
+    end
+  end
+
+  describe "decode_permissions" do
+    test "it decodes to an empty map when there are no permissions given" do
+      perms = %{profile: 0b1, user: 0}
+      result = __MODULE__.Impl.decode_permissions(perms)
+      assert result == %{profile: [:read], user: []}
+    end
+
+    test "it decodes when provided with an atom map" do
+      perms = %{profile: [:read], user: 0}
+      result = __MODULE__.Impl.decode_permissions(perms)
+      assert result == %{profile: [:read], user: []}
+
+      perms = %{profile: ["read"], user: 0}
+      result = __MODULE__.Impl.decode_permissions(perms)
+      assert result == %{profile: [:read], user: []}
+    end
+
+    test "it is ok with using max permissions" do
+      perms = %{profile: ["read"], user: -1}
+      result = __MODULE__.Impl.decode_permissions(perms)
+      assert result == %{profile: [:read], user: [:read, :write]}
+    end
+
+    test "when setting from an integer it ignores extra resolution" do
+      perms = %{profile: 0b1111, user: -1}
+      result = __MODULE__.Impl.decode_permissions(perms)
+      assert result == %{profile: [:read, :write], user: [:read, :write]}
+    end
+
+    test "it ignores unknown permission sets" do
+      perms = %{profile: 0b11, unknown: -1}
+      result = __MODULE__.Impl.decode_permissions(perms)
+      assert result == %{profile: [:read, :write]}
+    end
+  end
+
+  describe "when used as a plug" do
+    setup do
+      claims =
+        %{"sub" => "user:1"}
+        |> __MODULE__.Impl.build_claims(nil, permissions: %{user: [:read], profile: [:read]})
+
+      conn =
+        :get
+        |> conn("/")
+        |> Pipeline.call(module: __MODULE__.Impl, error_handler: __MODULE__.Handler)
+        |> GPlug.put_current_claims(claims)
+
+      {:ok, %{conn: conn, claims: claims}}
+    end
+
+    test "it does not allow when permissions are missing from ensure", ctx do
+      opts = GBits.init(ensure: %{user: [:write, :read], profile: [:read, :write]})
+      conn = GBits.call(ctx.conn, opts)
+
+      assert {403, _headers, body} = sent_resp(conn)
+      assert body == "{:unauthorized, :unauthorized}"
+      assert conn.halted
+    end
+
+    test "it does not allow when none of the one_of permissions match", ctx do
+      opts = GBits.init(one_of: [
+        %{user: [:write]},
+        %{profile: [:write]},
+        %{user: [:read], profile: [:write]},
+      ])
+
+      conn = GBits.call(ctx.conn, opts)
+
+      assert {403, _headers, body} = sent_resp(conn)
+      assert body == "{:unauthorized, :unauthorized}"
+      assert conn.halted
+    end
+
+    test "it allows the request when permissions from ensure match", ctx do
+      opts = GBits.init(ensure: %{user: [:read], profile: [:read]})
+      conn = GBits.call(ctx.conn, opts)
+
+      refute conn.halted
+
+      opts = GBits.init(ensure: %{user: [:read]})
+      conn = GBits.call(ctx.conn, opts)
+
+      refute conn.halted
+    end
+
+    test "it allows when one of the one of permissions from one_of match", ctx do
+      opts = GBits.init(one_of: [
+        %{user: [:write]},
+        %{profile: [:write]},
+        %{user: [:read]},
+      ])
+      conn = GBits.call(ctx.conn, opts)
+
+      refute conn.halted
+
+      opts = GBits.init(one_of: [
+        %{user: [:write]},
+        %{profile: [:write]},
+        %{profile: [:read]},
+      ])
+      conn = GBits.call(ctx.conn, opts)
+
+      refute conn.halted
+    end
+
+    test "when there is no logged in resource it fails" do
+      conn = :get |> conn("/") |> Pipeline.call(module: __MODULE__.Impl, error_handler: __MODULE__.Handler)
+
+      opts = GBits.init(ensure: %{user: [:read], profile: [:read]})
+      conn = GBits.call(conn, opts)
+
+      assert conn.halted
+      assert {403, _headers, body} = sent_resp(conn)
+      assert body == "{:unauthorized, :unauthorized}"
+    end
+
+    test "when looking in a different location with correct permissions", ctx do
+      opts = GBits.init(ensure: %{user: [:read], profile: [:read]}, key: :secret)
+      conn =
+        ctx.conn
+        |> GPlug.put_current_claims(ctx.claims, key: :secret)
+        |> GBits.call(opts)
+
+      refute conn.halted
+
+      opts = GBits.init(ensure: %{user: [:read]}, key: :secret)
+
+      conn =
+        ctx.conn
+        |> GPlug.put_current_claims(ctx.claims, key: :secret)
+        |> GBits.call(opts)
+
+      refute conn.halted
+    end
+
+    test "when looking in a different location with incorrect ensure permissions", ctx do
+      opts = GBits.init(ensure: %{user: [:read], profile: [:read]}, key: :secret)
+      conn = GBits.call(ctx.conn, opts)
+
+      assert conn.halted
+      assert {403, _headers, body} = sent_resp(conn)
+      assert body == "{:unauthorized, :unauthorized}"
+    end
+
+    test "when looking in a different location with incorrect one_of permissions", ctx do
+      opts = GBits.init(one_of: [%{user: [:read]}], key: :secret)
+      conn = GBits.call(ctx.conn, opts)
+
+      assert conn.halted
+      assert {403, _headers, body} = sent_resp(conn)
+      assert body == "{:unauthorized, :unauthorized}"
+    end
+
+    test "with no permissions specified", ctx do
+      opts = GBits.init([])
+      conn = GBits.call(ctx.conn, opts)
+      refute conn.halted
+    end
+  end
+end

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -243,7 +243,7 @@ defmodule GuardianTest do
       gather_function_calls()
       {:ok, token: token, claims: claims}
     end
-    
+
     test "it finds the resource", ctx do
       resource = @resource
       claims = ctx.claims


### PR DESCRIPTION
Adds permissions (bitwise) back into v1.

This implementation is a big update from what was previously there. 
The API has had a complete overhaul and the Plug component is entirely optional.

The permissions are entirely optional and must be included in the `build_claims` callback to become active. The documentation for `Guardian.Permissions.Bitwise` spells out how the new setup works.
