### PR TITLE
Update versions for phoenix and poison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v 0.14.5
+
+Update the poison and phoenix deps to allow a broader version setting
+
 # v 0.14.4
 
 * Fix a param issue in sockets

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Guardian.Mixfile do
   use Mix.Project
 
-  @version "0.14.4"
+  @version "0.14.5"
   @url "https://github.com/ueberauth/guardian"
   @maintainers [
     "Daniel Neighman",
@@ -42,9 +42,9 @@ defmodule Guardian.Mixfile do
 
   defp deps do
     [{:jose, "~> 1.8"},
-     {:phoenix, "~> 1.2", optional: true},
+     {:phoenix, "~> 1.2 and < 1.4.0", optional: true},
      {:plug, "~> 1.3"},
-     {:poison, ">= 1.3.0"},
+     {:poison, ">= 1.3.0 and < 4.0.0"},
      {:uuid, ">=1.1.1"},
 
      # Dev and Test dependencies


### PR DESCRIPTION
Updates the versions for pre 1.0 guardian to make reliance on phoenix and poison a bit more forgiving. Fixes https://github.com/ueberauth/guardian/issues/341