### PR TITLE
Add exception in case no secret key is set

### DIFF
--- a/lib/guardian/token/jwt.ex
+++ b/lib/guardian/token/jwt.ex
@@ -311,7 +311,11 @@ defmodule Guardian.Token.Jwt do
   end
 
   defp fetch_secret(mod, opts) do
-    opts |> Keyword.get(:secret) |> Config.resolve_value() || apply(mod, :config, [:secret_key])
+    (opts |> Keyword.get(:secret) |> Config.resolve_value() || apply(mod, :config, [:secret_key]))
+    |> case do
+      nil -> raise "No secret key configured for JWT"
+      val -> val
+    end
   end
 
   defp set_type(%{"typ" => typ} = claims, _mod, _opts) when not is_nil(typ), do: claims


### PR DESCRIPTION
While updating our application to use future Guardian 1.0.0, we led to an strange exception of JWT which ended being caused because the secret key was not set (well, it was set but using the old configuration).

This small PR adds a nicer and more clear exception in case no secret key is set.