### PR TITLE
Replace deprecated String.strip/1 with String.trim/1 for V1

### DIFF
--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -108,9 +108,9 @@ if Code.ensure_loaded?(Plug) do
 
     defp fetch_token_from_header(conn, opts, [token|tail]) do
       reg = Keyword.get(opts, :realm_reg, ~r/^(.*)$/)
-      trimmed_token = String.strip(token)
+      trimmed_token = String.trim(token)
       case Regex.run(reg, trimmed_token) do
-        [_, match] -> {:ok, String.strip(match)}
+        [_, match] -> {:ok, String.trim(match)}
         _ -> fetch_token_from_header(conn, opts, tail)
       end
     end


### PR DESCRIPTION
I got a couple warnings:
`warning: String.strip/1 is deprecated, use String.trim/1`

It looks like trim was implemented as far back at Elixir 1.3 (https://github.com/elixir-lang/elixir/blob/v1.3/lib/elixir/lib/string.ex#L831) so with our current dependencies of `elixir: ">= 1.3.2 or ~> 1.4 or ~> 1.5"` I believe we should be good swapping them out. 


Feel free to close this if merging #360 to master and then merging master to V1 is a better option. 