### PR TITLE
Replace deprecated String.strip/1 with String.trim/1

### DIFF
--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -79,12 +79,12 @@ defmodule Guardian.Plug.VerifyHeader do
   defp fetch_token(_, _, []), do: nil
 
   defp fetch_token(conn, opts = %{realm_reg: reg}, [token|tail]) do
-    trimmed_token = String.strip(token)
+    trimmed_token = String.trim(token)
     case Regex.run(reg, trimmed_token) do
-      [_, match] -> String.strip(match)
+      [_, match] -> String.trim(match)
       _ -> fetch_token(conn, opts, tail)
     end
   end
 
-  defp fetch_token(_, _, [token|_tail]), do: String.strip(token)
+  defp fetch_token(_, _, [token|_tail]), do: String.trim(token)
 end


### PR DESCRIPTION
I have another PR for V1, but I had already done this locally and figured we may as well fix it on master too? 

If we do it on master I guess we can close #359 and then fix V1 on the merge

Strim.trim/1 was implemented in Elixir 1.3 and we currently have `elixir: "~> 1.3",` in the project definition so I think its fine to switch to trim. 