### PR TITLE
Resource encode/decode requires a tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ defmodule MyApp.Guardian do
   use Guardian, otp_app: :my_app
 
   def subject_for_token(resource, _claims) do
-    to_string(resource.id)
+    {:ok, to_string(resource.id)}
   end
 
   def resource_from_claims(claims) do
-    find_me_a_resource(claims["sub"])
+    {:ok, find_me_a_resource(claims["sub"])}
   end
 end
 ```

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -295,6 +295,10 @@ defmodule Guardian do
 
   alias Guardian.Token.Verify
 
+  defmodule MalformedReturnValueError do
+    defexception [:message]
+  end
+
   defmacro __using__(opts \\ []) do
     alias Guardian.Config, as: GConfig
 
@@ -718,7 +722,9 @@ defmodule Guardian do
     case result do
       {:ok, _} -> result
       {:error, _} -> result
-      resp -> {:error, "Invalid return for #{mod}##{func} - #{inspect(resp)}"}
+      resp ->
+        raise MalformedReturnValueError,
+          message: "Expected `{:ok, result}` or `{:error, reason}` from #{mod}##{func}, got: #{inspect(resp)}"
     end
   end
 


### PR DESCRIPTION
I was following the README and ran into an error, turns out these functions need to return `{:ok, result}`.