### PR TITLE
Typespec keyword new_claims for (api_)sign_in

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -91,6 +91,7 @@ defmodule Guardian.Plug do
   def sign_in(conn, object, type), do: sign_in(conn, object, type, %{})
 
   @doc false
+  @spec sign_in(Plug.Conn.t, any, atom | String.t, Keyword.t) :: Plug.Conn.t
   def sign_in(conn, object, type, new_claims) when is_list(new_claims) do
     sign_in(conn, object, type, Enum.into(new_claims, %{}))
   end
@@ -153,6 +154,7 @@ defmodule Guardian.Plug do
   def api_sign_in(conn, object, type), do: api_sign_in(conn, object, type, %{})
 
   @doc false
+  @spec api_sign_in(Plug.Conn.t, any, atom | String.t, Keyword.t) :: Plug.Conn.t
   def api_sign_in(conn, object, type, new_claims) when is_list(new_claims) do
     api_sign_in(conn, object, type, Enum.into(new_claims, %{}))
   end


### PR DESCRIPTION
Encountered a warning from Dialyzer when calling Guardian.Plug.sign_in with keyword arguments. I decided it wouldn't hurt to specify that sign_in and its close relative api_sign_in can receive a keyword list instead of a map.