### PR TITLE
Remove anti-pattern configuration formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,9 @@ Some configuration may be required by your `token_module`
 
 ### Configuration values
 
-Guardian resolves different types of configuration values. These can be provided in the config or options as:
+Guardian supports resolving configuration options at runtime, to that we use the following syntax:
 
-* `{:system, "FOO"}` - Read from the system environment
-* `{MyModule, :function_name}` - To call a function and use the result
 * `{MyModule, :func, [:some, :args]}` Calls the function on the module with args
-* `fn -> :some_value end` - an anonymous function whose result will be used
-* any other value
 
 These are evaluated at runtime and any value that you fetch via
 

--- a/lib/guardian/config.ex
+++ b/lib/guardian/config.ex
@@ -12,11 +12,7 @@ defmodule Guardian.Config do
   * `fn -> :some_value end` - an anonymous function whose result will be used
   * any other value
   """
-  @type config_value :: {:system, String.t} |
-                        {module, atom} |
-                        {module, atom, list(any)} |
-                        fun |
-                        any
+  @type config_value :: {module, atom, list(any)} | any
 
   @doc """
   Resolves possible values from a configuration.
@@ -28,9 +24,6 @@ defmodule Guardian.Config do
   * value - Returns other values as is
   """
   @spec resolve_value(value :: config_value) :: any
-  def resolve_value({:system, name}), do: System.get_env(name)
-  def resolve_value({m, f}) when is_atom(m) and is_atom(f), do: apply(m, f, [])
   def resolve_value({m, f, a}) when is_atom(m) and is_atom(f), do: apply(m, f, a)
-  def resolve_value(f) when is_function(f, 0), do: apply(f, [])
   def resolve_value(v), do: v
 end

--- a/test/guardian/config_test.exs
+++ b/test/guardian/config_test.exs
@@ -6,10 +6,7 @@ defmodule Guardian.ConfigTest do
     @moduledoc false
     use Guardian, otp_app: :guardian,
                   issuer: "FooApp",
-                  system_foo: {:system, "FOO"},
-                  mod_fun_foo: {__MODULE__, :foo},
-                  mod_fun_args: {__MODULE__, :foo, [1]},
-                  fun: fn -> "blah" end
+                  mod_fun_args: {__MODULE__, :foo, [1]}
 
     use Guardian.TestHelper
 
@@ -30,22 +27,7 @@ defmodule Guardian.ConfigTest do
       :this_is_a_thing
   end
 
-  test "config with a system value" do
-    System.put_env("FOO", "")
-    assert Impl.config(:system_foo) == ""
-    System.put_env("FOO", "foo")
-    assert Impl.config(:system_foo) == "foo"
-  end
-
-  test "config with a {mod, fun}" do
-    assert Impl.config(:mod_fun_foo) == "module function foo"
-  end
-
   test "config with a {mod, fun, args}" do
     assert Impl.config(:mod_fun_args) == "mod fun args 1"
-  end
-
-  test "config with a function" do
-    assert Impl.config(:fun) == "blah"
   end
 end

--- a/test/guardian/token/jwt_test.exs
+++ b/test/guardian/token/jwt_test.exs
@@ -138,32 +138,12 @@ defmodule Guardian.Token.JwtTest do
       assert jwt.fields == ctx.claims
     end
 
-    test "it creates a token with an {m, f}", ctx do
-      secret = {ctx.impl, :the_secret_yo}
-      {:ok, token} = Jwt.create_token(ctx.impl, ctx.claims, secret: secret)
-      jwk = JWK.from_oct(ctx.impl.the_secret_yo)
-      {true, jwt, _} = JWT.verify_strict(jwk, ["HS512"], token)
-
-      assert jwt.fields == ctx.claims
-    end
-
     test "it creates a token with an {m, f, a}", ctx do
       the_secret = ctx.impl.config(:secret_key)
       secret = {ctx.impl, :the_secret_yo, [the_secret]}
       {:ok, token} = Jwt.create_token(ctx.impl, ctx.claims, secret: secret)
       jwk = JWK.from_oct(the_secret)
       {true, jwt, _} = JOSE.JWT.verify_strict(jwk, ["HS512"], token)
-
-      assert jwt.fields == ctx.claims
-    end
-
-    test "it creates a token with an secret function", ctx do
-      the_secret = ctx.impl.config(:secret_key)
-      secret = fn -> the_secret end
-
-      {:ok, token} = Jwt.create_token(ctx.impl, ctx.claims, secret: secret)
-      jwk = JWK.from_oct(the_secret)
-      {true, jwt, _} = JWT.verify_strict(jwk, ["HS512"], token)
 
       assert jwt.fields == ctx.claims
     end
@@ -187,23 +167,9 @@ defmodule Guardian.Token.JwtTest do
       assert {:ok, ctx.claims} == result
     end
 
-    test "it decodes the jwt with a module function", ctx do
-      secret = {ctx.impl, :the_secret_yo}
-      result = Jwt.decode_token(ctx.impl, ctx.jwt, secret: secret)
-      assert {:ok, ctx.claims} == result
-    end
-
     test "it decodes the jwt with an {m, f, a}", ctx do
       the_secret = ctx.impl.config(:secret_key)
       secret = {ctx.impl, :the_secret_yo, [the_secret]}
-      result = Jwt.decode_token(ctx.impl, ctx.jwt, secret: secret)
-      assert {:ok, ctx.claims} == result
-    end
-
-    test "it decodes the jwt with a :secret function", ctx do
-      the_secret = ctx.impl.config(:secret_key)
-      secret = fn -> the_secret end
-
       result = Jwt.decode_token(ctx.impl, ctx.jwt, secret: secret)
       assert {:ok, ctx.claims} == result
     end


### PR DESCRIPTION
Following the conversation in #377 and @bitwalker's latest comments, we should remove these anti-patterns from our configuration.

Thoughts questions/concerns/feedback?