### PR TITLE
Bumps the version of the beta

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Guardian.Mixfile do
   @moduledoc false
   use Mix.Project
 
-  @version "1.0.0-beta.0"
+  @version "1.0.0-beta.1"
   @url "https://github.com/ueberauth/guardian"
   @maintainers [
     "Daniel Neighman",


### PR DESCRIPTION
We removed the extraneous error handler file. I'd like to bump this up so we can get an update of guardian db out there.