### PR TITLE
Show example MyApp.Guardian.Plug in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ With this level of configuration you can have a working installation.
 
 With Plug
 
+Create a module that uses `Guardian.Plug`
+
+With bare Plug or Phoenix 1.2
+
+```elixir
+defmodule MyApp.Guardian.Plug do
+  use Guardian.Plug, MyApp.Guardian
+end
+```
+
+In Phoenix 1.3, Phoenix puts the web interface in a separate namespace with a `Web` suffix, so use that namespace for the module instead
+
+```elixir
+defmodule MyAppWeb.Guardian.Plug do
+  use Guardian.Plug, MyApp.Guardian
+end
+```
+
+Call `MyApp.Guardian.Plug` or (`MyAppWeb.Guardian.Plug` if using Phoenix 1.3)
+
 ```elixir
 # If a session is loaded the token/resource/claims will be put into the session and connection
 # If no session is loaded, the token/resource/claims only go onto the connection


### PR DESCRIPTION
Unlike `MyApp.Guardian`, there is no explanation of where `MyApp.Guardian.Plug` comes from in `README.md`. I was only able to figure it out by seeing that `Guardian.Plug` had a `__using__` macro and seeing that it accepted a `implementation` argument.  This was a stumbling block for myself and someone I was mentoring, so I've added an example and included the different naming scheme for Phoenix 1.2 vs Phoenix 1.3  I know Guardian really only talks about Plug, but since a lot of developers use it in Phoenix, I thought it was worth tailoring the examples to the differences in the Phoenix versions.  If you don't want to include Phoenix-isms in the docs, I can remove the `MyAppWeb.Guardian.Plug` example.