### PR TITLE
Adding halt to the error pipeline

### DIFF
--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -91,6 +91,7 @@ if Code.ensure_loaded?(Plug) do
           conn
           |> Pipeline.fetch_error_handler!(opts)
           |> apply(:auth_error, [conn, {:invalid_token, reason}, opts])
+          |> halt()
         _ -> conn
       end
     end

--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -61,6 +61,7 @@ if Code.ensure_loaded?(Plug) do
           conn
           |> Pipeline.fetch_error_handler!(opts)
           |> apply(:auth_error, [conn, {:invalid_token, reason}, opts])
+          |> halt()
         _ -> conn
       end
     end


### PR DESCRIPTION
This PR solves #401 by adding `halt()` to `verify_header.ex` and `verify_session.ex`