### PR TITLE
Peeking the way it was implemented does not work for non-jwt token types

### DIFF
--- a/lib/guardian/token.ex
+++ b/lib/guardian/token.ex
@@ -26,7 +26,7 @@ defmodule Guardian.Token do
   @doc """
   Inspect the contents of the token without validation or signature checking
   """
-  @callback peek(token :: token) :: map
+  @callback peek(module :: module, token :: token) :: map
 
   @doc """
   Generate a unique id for a token

--- a/lib/guardian/token/jwt.ex
+++ b/lib/guardian/token/jwt.ex
@@ -129,9 +129,9 @@ defmodule Guardian.Token.Jwt do
 
   Return an map with keys: `headers` and `claims`
   """
-  def peek(nil), do: nil
+  def peek(_mod, nil), do: nil
 
-  def peek(token) do
+  def peek(_mod, token) do
     %{headers: JWT.peek_protected(token).fields, claims: JWT.peek_payload(token).fields}
   end
 

--- a/test/guardian/token/jwt_test.exs
+++ b/test/guardian/token/jwt_test.exs
@@ -88,11 +88,11 @@ defmodule Guardian.Token.JwtTest do
 
   describe "peek" do
     test "with a nil token", %{token_mod: mod} do
-      assert apply(mod, :peek, [nil]) == nil
+      assert mod.peek(Impl, nil) == nil
     end
 
     test "with a valid token", %{token_mod: mod, jwt: jwt, claims: claims} do
-      result = apply(mod, :peek, [jwt])
+      result = mod.peek(Impl, jwt)
       assert result == %{
         headers: %{"typ" => "JWT"},
         claims: claims

--- a/test/support/token_module.ex
+++ b/test/support/token_module.ex
@@ -11,7 +11,7 @@ defmodule Guardian.Support.TokenModule do
     UUID.uuid4()
   end
 
-  def peek(token) do
+  def peek(_mod, token) do
     claims =
       token
       |> Base.decode64!()


### PR DESCRIPTION
Unfortunately peeking - via the underlying api - would potentially not work for other token types.

This addresses this issue by ensuring that peek is pushed through the implementation module rather than skipping it and going directly to the token module.