### PR TITLE
fix remember_me plug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ erl_crash.dump
 *.ez
 doc
 .DS_Store
+.elixir_ls/

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -205,37 +205,37 @@ if Code.ensure_loaded?(Plug) do
     @spec remember_me(Plug.Conn.t(), module, any, Guardian.Token.claims(), Guardian.opts()) ::
             Plug.Conn.t()
     def remember_me(conn, mod, resource, claims \\ %{}, opts \\ []) do
-      with type <- Keyword.get(opts, :token_type, "refresh"),
-           opts <- Keyword.put(opts, :token_type, type),
-           key <- conn |> Pipeline.fetch_key(opts) |> token_key() |> Atom.to_string(),
-           {:ok, token, full_claims} <- Guardian.encode_and_sign(mod, resource, claims, opts) do
-        
-        cookie_opts = cookie_options(mod, full_claims)
-        put_resp_cookie(conn, key, token, cookie_opts)
+      opts = Keyword.put_new(opts, :token_type, "refresh")
+      key = fetch_token_key(conn, opts)
+
+      case Guardian.encode_and_sign(mod, resource, claims, opts) do
+        {:ok, token, new_claims} -> 
+          put_resp_cookie(conn, key, token, cookie_options(mod, new_claims))
+        {:error, _} = err -> 
+          handle_unauthenticated(conn, err, opts)
+      end
+    end
+
+    @spec remember_me_from_token(Plug.Conn.t(), module, Guardian.Token.token(), Guardian.Token.claims(), Guardian.opts()) :: 
+            Plug.Conn.t()
+    def remember_me_from_token(conn, mod, token, claims_to_check \\ %{}, opts \\ []) do
+      token_type = Keyword.get(opts, :token_type, "refresh")
+      key = fetch_token_key(conn, opts)
+
+      with {:ok, claims} <- Guardian.decode_and_verify(mod, token, claims_to_check, opts),
+           {:ok, _old, {new_t, full_new_c}} <- Guardian.exchange(mod, token, claims["typ"], token_type, opts) 
+      do
+        put_resp_cookie(conn, key, new_t, cookie_options(mod, full_new_c))
       else
         {:error, _} = err -> handle_unauthenticated(conn, err, opts)
       end
     end
 
-    @spec remember_me_from_token(
-            Plug.Conn.t(),
-            module,
-            Guardian.Token.token(),
-            Guardian.Token.claims(),
-            Guardian.opts()
-          ) :: Plug.Conn.t()
-    def remember_me_from_token(conn, mod, token, claims_to_check \\ %{}, opts \\ []) do
-      with {:ok, claims} <- Guardian.decode_and_verify(mod, token, claims_to_check, opts),
-           type <- Keyword.get(opts, :token_type, "refresh"),
-           key <- conn |> Pipeline.fetch_key(opts) |> token_key() |> Atom.to_string(),
-           {:ok, _old, {new_t, full_new_c}} <-
-             Guardian.exchange(mod, token, claims["typ"], type, opts) do
-
-        cookie_opts = cookie_options(mod, full_new_c)
-        put_resp_cookie(conn, key, new_t, cookie_opts)
-      else
-        {:error, _} = err -> handle_unauthenticated(conn, err, opts)
-      end
+    defp fetch_token_key(conn, opts) do
+      conn
+      |> Pipeline.fetch_key(opts)
+      |> token_key()
+      |> Atom.to_string()
     end
 
     defp cookie_options(mod, %{"exp" => timestamp}) do

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -42,7 +42,7 @@ if Code.ensure_loaded?(Plug) do
     end
 
     @default_key "default"
-    @default_cookie_options [secure: true, max_age: 60 * 60 * 24 * 7 * 4]
+    @default_cookie_options [max_age: 60 * 60 * 24 * 7 * 4]
 
     import Guardian, only: [returning_tuple: 1]
     import Guardian.Plug.Keys
@@ -77,6 +77,10 @@ if Code.ensure_loaded?(Plug) do
           do: GPlug.sign_in(conn, implementation(), resource, claims, opts)
 
         def sign_out(conn, opts \\ []), do: GPlug.sign_out(conn, implementation(), opts)
+
+        def remember_me(conn, mod, resource, claims \\ %{}, opts \\ []), do: GPlug.remember_me(conn, mod, resource, claims, opts)
+        
+        def remember_me_from_token(conn, mod, token, claims \\ %{}, opts \\ []), do: GPlug.remember_me_from_token(conn, mod, token, claims, opts)
       end
     end
 

--- a/lib/guardian/plug/verify_cookie.ex
+++ b/lib/guardian/plug/verify_cookie.ex
@@ -20,7 +20,9 @@ if Code.ensure_loaded?(Plug) do
     3. Inline with an option of `:module`, `:error_handler`, `:key`
 
     If a token is found but is invalid, the error handler will be called with
-    `auth_error(conn, {:invalid_token, reason}, opts)`
+    `auth_error(conn, {:invalid_token, reason}, opts)
+
+    If a token is expired, the error handler WONT be called, the error can be handled with the ensure_authenticated plug
 
     Once a token has been found it will be exchanged for an access (default) token.
     This access token will be placed into the session and connection.
@@ -66,6 +68,9 @@ if Code.ensure_loaded?(Plug) do
         |> maybe_put_in_session(active_session?, new_t, key)
       else
         :no_token_found ->
+          conn
+        # Let the ensure_authenticated plug handle the token expired later in the pipeline
+        {:error, :token_expired} ->
           conn
 
         {:error, reason} ->

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -350,10 +350,8 @@ defmodule Guardian.PlugTest do
       assert %Plug.Conn{} = xconn = GPlug.remember_me(conn, ctx.impl, @resource, %{}, [])
 
       assert Map.has_key?(xconn.resp_cookies, "guardian_default_token")    
-      %{secure: secure, value: token, max_age: max_age} = Map.get(xconn.resp_cookies, "guardian_default_token")
+      %{value: token, max_age: max_age} = Map.get(xconn.resp_cookies, "guardian_default_token")
       
-      #make sure that the cookie secure options is set by default
-      assert secure
       #default max age
       assert max_age == 2419200
       assert token
@@ -377,10 +375,8 @@ defmodule Guardian.PlugTest do
       assert %Plug.Conn{} = xconn = GPlug.remember_me_from_token(conn, ctx.impl, old_token, claims)
 
       assert Map.has_key?(xconn.resp_cookies, "guardian_default_token")    
-      %{secure: secure, value: new_token, max_age: max_age} = Map.get(xconn.resp_cookies, "guardian_default_token")
+      %{value: new_token, max_age: max_age} = Map.get(xconn.resp_cookies, "guardian_default_token")
       
-      #make sure that the cookie secure options is set by default
-      assert secure
       #default max age
       assert max_age == 2419200
       assert new_token

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -351,9 +351,12 @@ defmodule Guardian.PlugTest do
 
       assert Map.has_key?(xconn.resp_cookies, "guardian_default_token")    
       %{secure: secure, value: token, max_age: max_age} = Map.get(xconn.resp_cookies, "guardian_default_token")
+      
+      #make sure that the cookie secure options is set by default
       assert secure
+      #default max age
+      assert max_age == 2419200
       assert token
-      assert max_age == 1000
 
       claims = %{"sub" => "bobby", "typ" => "refresh"}
       ops = [token_type: "refresh"]

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -388,11 +388,11 @@ defmodule Guardian.PlugTest do
         #decode and verify the old token
         {Guardian.Support.TokenModule, :decode_token,  [ctx.impl, old_token, []]},
         {Guardian.Support.TokenModule, :verify_claims, [ctx.impl, claims, []]},
-        #as part of the exhange we decode and verfify the old token again
+        #as part of the exchange we decode and verify the old token again
         {Guardian.Support.TokenModule, :decode_token,  [ctx.impl, old_token, []]},
         {Guardian.Support.TokenModule, :verify_claims, [ctx.impl, claims, []]},
         {Guardian.Support.TokenModule, :exchange,      [ctx.impl, old_token, "refresh", "refresh", []]},
-        #as part of the exhange we decode the old token to get the claims
+        #as part of the exchange we decode the old token to get the claims
         {Guardian.Support.TokenModule, :decode_token,  [ctx.impl, old_token, []]}
       ]
 


### PR DESCRIPTION
Fix for #405 
Whats need to be done:
- [x] Save the token under the key: guardian_"key"_token, so the verify cookie plug finds it
- [x] Set the secure property on the cookie, so it will only be sent over https
- [x] Set the max_age property on the cookie, should properly be the same as the ttl of the token, is there a convenient way to get the ttl of a token? 
- [x] More tests
- [x] Update docs, see #386  
- [x] Decide if sign_out should also clear the remeber_me cookie
- [x] Decide if we should ignore the token expired error and let Plug.EnsureAuthenticated handle it
