### PR TITLE
Updated README to remove `ensure: true` from Plug example

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ defmodule MyApp.AuthAccessPipeline do
   plug Guardian.Plug.VerifySession, claims: %{"typ" => "access"}
   plug Guardian.Plug.VerifyHeader, claims: %{"typ" => "access"}
   plug Guardian.Plug.EnsureAuthenticated
-  plug Guardian.Plug.LoadResource, ensure: true
+  plug Guardian.Plug.LoadResource
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -295,9 +295,12 @@ defmodule MyApp.AuthAccessPipeline do
   plug Guardian.Plug.VerifySession, claims: %{"typ" => "access"}
   plug Guardian.Plug.VerifyHeader, claims: %{"typ" => "access"}
   plug Guardian.Plug.EnsureAuthenticated
-  plug Guardian.Plug.LoadResource
+  plug Guardian.Plug.LoadResource, allow_blank: true
 end
 ```
+
+By default, the LoadResource plug will return an error if no resource can be found.
+You can override this behaviour using the `allow_blank: true` option.
 
 Add your implementation module and error handler to your configuration:
 


### PR DESCRIPTION
The `Guardian.Plug.LoadResource` plug no longer takes an `ensure: true` option, this PR removes that from the README.