### PR TITLE
Bad practice to exchange access token for access token

### DIFF
--- a/upgrade_guides/0.14.to.1.0.md
+++ b/upgrade_guides/0.14.to.1.0.md
@@ -144,7 +144,7 @@ MyApp.Guardian.encode_and_sign(resource, %{}, secret: resolvable_config_value)
 
 ```elixir
   {:ok, {old_token, old_claims}, {new_token, new_claims}} =
-    MyApp.Guardian.exchange(old_token, ["access", "refresh"], "access")
+    MyApp.Guardian.exchange(old_token, ["refresh"], "access")
 ```
 
 ### Refresh


### PR DESCRIPTION
I think its bad practice to exchange an access token to an access token. If you want to do that you should properly use the refresh function. Even though it just the upgrade guide, I still think we should teach user the correct way of using the library 