### PR TITLE
Improve documentation for verify_header plug module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Guardian
-========
+# Guardian
 
 > An authentication library for use with Elixir applications.
 
@@ -196,13 +195,13 @@ The default token type of `Guardian` is JWT. It accepts many options but you rea
 
 * `issuer` - The issuer of the token. Your application name/id
 * `secret_key` - The secret key to use for the implementation module.
-                 This may be any resolvable value for `Guardian.Config`
+  This may be any resolvable value for `Guardian.Config`
 
 #### Optional configuration (JWT)
 
 * `token_verify_module` - default `Guardian.Token.Jwt.Verify`. The module that verifies the claims
 * `allowed_algos` - The allowed algos to use for encoding and decoding.
-                    See `JOSE` for available. Default `["HS512"]`
+  See `JOSE` for available. Default `["HS512"]`
 * `ttl` - The default time to live for all tokens. See the type in Guardian.ttl
 * `token_ttl` a map of `token_type` to `ttl`. Set specific ttls for specific types of tokens
 * `allowed_drift` The drift that is allowed when decoding/verifying a token in milliseconds
@@ -271,21 +270,27 @@ claims = MyApp.Guardian.Plug.current_claims(conn, key: :impersonate)
 ### Plugs out of the box
 
 #### `Guardian.Plug.VerifyHeader`
+
 Look for a token in the header and verify it
 
 #### `Guardian.Plug.VerifySession`
+
 Look for a token in the session and verify it
 
 #### `Guardian.Plug.VerifyCookie`
+
 Look for a token in cookies and exchange it for an access token
 
 #### `Guardian.Plug.EnsureAuthenticated`
+
 Make sure that a token was found and is valid
 
 #### `Guardian.Plug.EnsureNotAuthenticated`
+
 Make sure no one is logged in
 
 #### `Guardian.Plug.LoadResource`
+
 If a token was found, load the resource for it
 
 See the documentation for each Plug for more information.
@@ -387,9 +392,10 @@ This will record each token issued in your database, confirm it is still valid o
 
 For more in-depth documentation please see the [GuardianDb README](https://github.com/ueberauth/guardian_db/blob/master/README.md)
 
-## Best testing practises
+## Best testing practices
 
 ### How to add the token to a request (the Phoenix way)
+
 ```elixir
 {:ok, token, _} = encode_and_sign(resource, %{}, token_type: :access)
 conn = conn

--- a/README.md
+++ b/README.md
@@ -387,6 +387,16 @@ This will record each token issued in your database, confirm it is still valid o
 
 For more in-depth documentation please see the [GuardianDb README](https://github.com/ueberauth/guardian_db/blob/master/README.md)
 
+## Best testing practises
+
+### How to add the token to a request (the Phoenix way)
+```elixir
+{:ok, token, _} = encode_and_sign(resource, %{}, token_type: :access)
+conn = conn
+|> put_req_header("authorization", "bearer: " <> token)
+|> get(auth_path(conn, :me))
+```
+
 ## Related projects
 
 * [GuardianDb](https://hex.pm/packages/guardian_db) - Token tracking in the database

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ defmodule HelloWeb.AuthControllerTest do
   import HelloWeb.Guardian
 
  test "GET /auth/me", %{conn: conn} do
-    user = insert(:user) // See https://github.com/thoughtbot/ex_machina
+    user = insert(:user) # See https://github.com/thoughtbot/ex_machina
 
     {:ok, token, _} = encode_and_sign(user, %{}, token_type: :access)
 

--- a/README.md
+++ b/README.md
@@ -397,10 +397,23 @@ For more in-depth documentation please see the [GuardianDb README](https://githu
 ### How to add the token to a request (the Phoenix way)
 
 ```elixir
-{:ok, token, _} = encode_and_sign(resource, %{}, token_type: :access)
-conn = conn
-|> put_req_header("authorization", "bearer: " <> token)
-|> get(auth_path(conn, :me))
+defmodule HelloWeb.AuthControllerTest do
+  use HelloWeb.ConnCase
+  import HelloWeb.Guardian
+
+ test "GET /auth/me", %{conn: conn} do
+    user = insert(:user) // See https://github.com/thoughtbot/ex_machina
+
+    {:ok, token, _} = encode_and_sign(user, %{}, token_type: :access)
+
+    conn = conn
+    |> put_req_header("authorization", "bearer: " <> token)
+    |> get(auth_path(conn, :me))
+
+    # Assert things here
+  end
+
+end
 ```
 
 ## Related projects


### PR DESCRIPTION
I'm new to elixir and its ecosystem thus i'm starting to learn its ins and outs including guardian. I love how easy testing is with elixir but I couldn't understand why my test couldn't pass thus I had to dig through the code to understand how the header is parsed by default. I think adding a few line of documentation could help the next guy experience.