### PR TITLE
Fix incorrect session token key for VerifyCookie

### DIFF
--- a/lib/guardian/plug/verify_cookie.ex
+++ b/lib/guardian/plug/verify_cookie.ex
@@ -63,7 +63,7 @@ if Code.ensure_loaded?(Plug) do
         conn
         |> GPlug.put_current_token(new_t, key: key)
         |> GPlug.put_current_claims(new_c, key: key)
-        |> maybe_put_in_session(active_session?, new_t, key)
+        |> maybe_put_in_session(active_session?, new_t, opts)
       else
         :no_token_found ->
           conn
@@ -86,7 +86,10 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp maybe_put_in_session(conn, false, _, _), do: conn
-    defp maybe_put_in_session(conn, true, token, key), do: put_session(conn, key, token)
+    defp maybe_put_in_session(conn, true, token, opts) do
+      key = conn |> storage_key(opts) |> token_key()
+      put_session(conn, key, token)
+    end
 
     defp storage_key(conn, opts), do: Pipeline.fetch_key(conn, opts)
   end


### PR DESCRIPTION
# The fix

This addresses an integration issue between `VerifyCookie` and `VerifySession`.

For these two things to work together they need to agree on the key that is present in `plug_session`.

## VerifySession

Gets the key it uses [here](https://github.com/ueberauth/guardian/blob/master/lib/guardian/plug/verify_session.ex#L73):

```
key = conn |> storage_key(opts) |> token_key()
token = get_session(conn, key)
```

The call to `storage_key` [defers to the Pipeline](https://github.com/ueberauth/guardian/blob/master/lib/guardian/plug/verify_session.ex#L78)

```
Pipeline.fetch_key(conn, opts)
```

And then passes it through [`token_key/1`](https://github.com/ueberauth/guardian/blob/master/lib/guardian/plug/keys.ex#L26)

## VerifyCookie
Puts the session [here](https://github.com/ueberauth/guardian/blob/master/lib/guardian/plug/verify_cookie.ex#L89)

```
put_session(conn, key, token)
```

This `key` comes from [here](https://github.com/ueberauth/guardian/blob/master/lib/guardian/plug/verify_cookie.ex#L91)

```
Pipeline.fetch_key(conn, opts)
```

_What is missing is the call to `token_key/1`_.

Since these two do not agree with one another these Plugs will not work as intended (or at least according to what my understanding of the intention is).

# The test

Currently the test that I wrote is failing when I believe it should be passing. There is an issue with the token that is being generated. I'll keep working on this.