### PR TITLE
fix dialyzer error

### DIFF
--- a/lib/guardian/plug/pipeline.ex
+++ b/lib/guardian/plug/pipeline.ex
@@ -226,6 +226,7 @@ if Code.ensure_loaded?(Plug) do
     defp maybe_put_key(conn, _, nil), do: conn
     defp maybe_put_key(conn, key, v), do: put_private(conn, key, v)
 
+    @spec raise_error :: no_return
     defp raise_error(key), do: raise("`#{key}` not set in Guardian pipeline")
   end
 end


### PR DESCRIPTION
Fixes
```
lib/my_app_web/auth_pipeline.ex:4: Function raise_error/1 only terminates with explicit exception
```
when compiling auth pipelines with `error_handling` dialyzer option