### PR TITLE
fix dialyzer error

### DIFF
--- a/lib/guardian/plug/pipeline.ex
+++ b/lib/guardian/plug/pipeline.ex
@@ -170,6 +170,7 @@ if Code.ensure_loaded?(Plug) do
           Pipeline.call(conn, pipeline_opts)
         end
 
+        @spec raise_error(atom()) :: no_return
         defp raise_error(key), do: raise("Config `#{key}` is missing for #{__MODULE__}")
       end
     end


### PR DESCRIPTION
Fixes
```
lib/my_app_web/auth_pipeline.ex:4: Function raise_error/1 only terminates with explicit exception
```
when compiling auth pipelines with `error_handling` dialyzer option