### PR TITLE
Add UserSocket.ex example to upgrade guide

### DIFF
--- a/upgrade_guides/0.14.to.1.0.md
+++ b/upgrade_guides/0.14.to.1.0.md
@@ -288,6 +288,58 @@ The macros that were provided for Phoenix sockets and channels have been removed
 * `Guardian.Phoenix.Socket.current_token`
 * `Guardian.Phoenix.Socket.current_resource`
 
+0.14.x
+
+```elixir
+defmodule MyApp.UserSocket do
+  use Phoenix.Socket
+  use Guardian.Phoenix.Socket
+  
+  ## Channels
+  channel "user:*", MyApp.UserChannel, timeout: 45_000
+
+  ## Transports
+  transport :websocket, Phoenix.Transports.WebSocket
+  # transport :longpoll, Phoenix.Transports.LongPoll
+
+  def connect(_params, _socket) do
+    :error
+  end
+
+  def id(socket), do: "users_socket:#{current_resource(socket).id}"
+end
+```
+
+1.0
+
+```elixir
+defmodule MyApp.UserSocket do
+  use Phoenix.Socket
+
+  ## Channels
+  channel "user:*", MyApp.UserChannel, timeout: 45_000
+
+  ## Transports
+  transport :websocket, Phoenix.Transports.WebSocket
+  # transport :longpoll, Phoenix.Transports.LongPoll
+
+  def connect(%{"guardian_token" => token}, socket) do
+    case Guardian.Phoenix.Socket.authenticate(socket, MyApp.Guardian, token) do
+      {:ok, authed_socket} ->
+        {:ok, authed_socket}
+
+      {:error, _} ->
+        :error
+    end
+  end
+  def connect(_params, _socket) do
+    :error
+  end
+
+  def id(socket), do: "users_socket:#{Guardian.Phoenix.Socket.current_resource(socket).id}"
+end
+```
+
 ## Permissions
 Permissions are not always active anymore. These have become optional and renamed to be more clear.
 


### PR DESCRIPTION
It took me some time to figure out what needs to be done with Phoenix Channels after the 1.0 upgrade. Hopefully this example will make it clear for everyone else.

The example is copied from the 1.0 docs, with one notable change:
```elixir
def connect(%{"guardian_token" => token}, socket) do
```
The 0.14.x documentation uses `guardian_token` as param name in the examples, so most people (including myself) would probably use that instead of `token`.

