### PR TITLE
Add link to hex docs in readme and correct typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Tokens should be able to contain any assertions (claims) that a developer wants 
 Guardian also allows you to configure multiple token types/configurations in a single application.
 
 ## Documentation
+
 API documentation is available at [https://hexdocs.pm/guardian](https://hexdocs.pm/guardian)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Tokens should be able to contain any assertions (claims) that a developer wants 
 
 Guardian also allows you to configure multiple token types/configurations in a single application.
 
+## Documentation
+API documentation is available at [https://hexdocs.pm/guardian](https://hexdocs.pm/guardian)
+
 ## Installation
 
 Guardian requires that you create an "Implementation Module". This module is your applications implementation for a particular type/configuration of token. You do this by `use`ing Guardian in your module and adding the relevant configuration.

--- a/lib/guardian/phoenix/socket.ex
+++ b/lib/guardian/phoenix/socket.ex
@@ -24,7 +24,7 @@ if Code.ensure_loaded?(Phoenix) do
 
     There is a bit of a difference between the usual `Guardian.Plug.sign_in` and the socket one.
     The socket authenticate receives a token and signs in from that.
-    Please note that this is mere sugar on the underlying Guarian functions.
+    Please note that this is mere sugar on the underlying Guardian functions.
 
     As an example:
     ```elixir


### PR DESCRIPTION
I was reading the README to find more information about using Guardian with Phoenix channels, and noticed that it said to read more about it in the docs, but there was no link.

This adds a link as well as fixes a typo I found in the documentation that I was looking for.

Thanks for all the work on this project!