### PR TITLE
Call hook to revoke token when using Plug.sign_out

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -307,12 +307,9 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp revoke_token(conn, impl, key, opts) do
-      claims = current_claims(conn, key: key)
       token = current_token(conn, key: key)
 
-      with {:ok, _} <-
-          returning_tuple({impl, :on_revoke, [claims, token, opts]}),
-        do: {:ok, conn}
+      with {:ok, _} <- impl.revoke(token, opts), do: {:ok, conn}
     end
 
     defp do_sign_out(%{private: private} = conn, impl, :all, opts) do

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -51,6 +51,16 @@ defmodule Guardian.PlugTest do
 
       {:ok, conn}
     end
+
+    def on_revoke(claims, token, opts) do
+      send_function_call({
+        __MODULE__,
+        :on_revoke,
+        [claims, token, opts]
+      })
+
+      {:ok, claims}
+    end
   end
 
   setup do
@@ -242,7 +252,8 @@ defmodule Guardian.PlugTest do
     end
 
     test "it calls the right things", ctx do
-      conn = ctx.conn
+      %{conn: conn, bob: %{token: bob_token, claims: bob_claims}} = ctx
+
       assert %Plug.Conn{} = xconn = GPlug.sign_out(conn, ctx.impl, key: :bob)
 
       refute xconn.private[:guardian_bob_token]
@@ -257,13 +268,21 @@ defmodule Guardian.PlugTest do
 
       assert get_session(xconn, :guardian_jane_token)
 
-      expected = [{ctx.impl, :before_sign_out, [:conn, :bob, [key: :bob]]}]
+      expected = [
+        {ctx.impl, :before_sign_out, [:conn, :bob, [key: :bob]]},
+        {ctx.impl, :on_revoke, [bob_claims, bob_token, [key: :bob]]}
+      ]
 
       assert gather_function_calls() == expected
     end
 
     test "is removes all users", ctx do
-      conn = ctx.conn
+      %{
+        conn: conn,
+        bob: %{token: bob_token, claims: bob_claims},
+        jane: %{token: jane_token, claims: jane_claims}
+      } = ctx
+
       assert %Plug.Conn{} = xconn = GPlug.sign_out(conn, ctx.impl, [])
 
       refute xconn.private[:guardian_bob_token]
@@ -280,7 +299,9 @@ defmodule Guardian.PlugTest do
 
       expected = [
         {ctx.impl, :before_sign_out, [:conn, :bob, []]},
-        {ctx.impl, :before_sign_out, [:conn, :jane, []]}
+        {ctx.impl, :on_revoke, [bob_claims, bob_token, []]},
+        {ctx.impl, :before_sign_out, [:conn, :jane, []]},
+        {ctx.impl, :on_revoke, [jane_claims, jane_token, []]}
       ]
 
       assert gather_function_calls() == expected
@@ -317,7 +338,8 @@ defmodule Guardian.PlugTest do
     end
 
     test "it calls the right things", ctx do
-      conn = ctx.conn
+      %{conn: conn, bob: %{token: bob_token, claims: bob_claims}} = ctx
+
       assert %Plug.Conn{} = xconn = GPlug.sign_out(conn, ctx.impl, key: :bob)
 
       refute xconn.private[:guardian_bob_token]
@@ -328,12 +350,21 @@ defmodule Guardian.PlugTest do
       assert xconn.private[:guardian_jane_claims]
       assert xconn.private[:guardian_jane_resource]
 
-      expected = [{Guardian.PlugTest.Impl, :before_sign_out, [:conn, :bob, [key: :bob]]}]
+      expected = [
+        {Guardian.PlugTest.Impl, :before_sign_out, [:conn, :bob, [key: :bob]]},
+        {Guardian.PlugTest.Impl, :on_revoke, [bob_claims, bob_token, [key: :bob]]}
+      ]
+
       assert gather_function_calls() == expected
     end
 
     test "is removes all users", ctx do
-      conn = ctx.conn
+      %{
+        conn: conn,
+        bob: %{token: bob_token, claims: bob_claims},
+        jane: %{token: jane_token, claims: jane_claims}
+      } = ctx
+
       assert %Plug.Conn{} = xconn = GPlug.sign_out(conn, ctx.impl, [])
 
       refute xconn.private[:guardian_bob_token]
@@ -346,7 +377,9 @@ defmodule Guardian.PlugTest do
 
       expected = [
         {Guardian.PlugTest.Impl, :before_sign_out, [:conn, :bob, []]},
-        {Guardian.PlugTest.Impl, :before_sign_out, [:conn, :jane, []]}
+        {Guardian.PlugTest.Impl, :on_revoke, [bob_claims, bob_token, []]},
+        {Guardian.PlugTest.Impl, :before_sign_out, [:conn, :jane, []]},
+        {Guardian.PlugTest.Impl, :on_revoke, [jane_claims, jane_token, []]}
       ]
 
       assert gather_function_calls() == expected

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -226,9 +226,9 @@ defmodule Guardian.PlugTest do
     setup %{conn: conn} do
       conn = init_test_session(conn, %{})
       bob_claims = %{"sub" => "User:#{@bob.id}"}
-      bob_token = Poison.encode!(%{claims: bob_claims})
+      bob_token = Poison.encode!(%{claims: bob_claims}) |> Base.encode64()
       jane_claims = %{"sub" => "User:#{@jane.id}"}
-      jane_token = Poison.encode!(%{claims: jane_claims})
+      jane_token = Poison.encode!(%{claims: jane_claims}) |> Base.encode64()
 
       conn =
         conn
@@ -270,6 +270,7 @@ defmodule Guardian.PlugTest do
 
       expected = [
         {ctx.impl, :before_sign_out, [:conn, :bob, [key: :bob]]},
+        {Guardian.Support.TokenModule, :revoke, [ctx.impl, bob_claims, bob_token, [key: :bob]]},
         {ctx.impl, :on_revoke, [bob_claims, bob_token, [key: :bob]]}
       ]
 
@@ -299,8 +300,10 @@ defmodule Guardian.PlugTest do
 
       expected = [
         {ctx.impl, :before_sign_out, [:conn, :bob, []]},
+        {Guardian.Support.TokenModule, :revoke, [ctx.impl, bob_claims, bob_token, []]},
         {ctx.impl, :on_revoke, [bob_claims, bob_token, []]},
         {ctx.impl, :before_sign_out, [:conn, :jane, []]},
+        {Guardian.Support.TokenModule, :revoke, [ctx.impl, jane_claims, jane_token, []]},
         {ctx.impl, :on_revoke, [jane_claims, jane_token, []]}
       ]
 
@@ -314,9 +317,9 @@ defmodule Guardian.PlugTest do
 
     setup %{conn: conn} do
       bob_claims = %{"sub" => "User:#{@bob.id}"}
-      bob_token = Poison.encode!(%{claims: bob_claims})
+      bob_token = Poison.encode!(%{claims: bob_claims}) |> Base.encode64()
       jane_claims = %{"sub" => "User:#{@jane.id}"}
-      jane_token = Poison.encode!(%{claims: jane_claims})
+      jane_token = Poison.encode!(%{claims: jane_claims}) |> Base.encode64()
 
       conn =
         conn
@@ -352,6 +355,8 @@ defmodule Guardian.PlugTest do
 
       expected = [
         {Guardian.PlugTest.Impl, :before_sign_out, [:conn, :bob, [key: :bob]]},
+        {Guardian.Support.TokenModule, :revoke,
+         [Guardian.PlugTest.Impl, bob_claims, bob_token, [key: :bob]]},
         {Guardian.PlugTest.Impl, :on_revoke, [bob_claims, bob_token, [key: :bob]]}
       ]
 
@@ -377,8 +382,12 @@ defmodule Guardian.PlugTest do
 
       expected = [
         {Guardian.PlugTest.Impl, :before_sign_out, [:conn, :bob, []]},
+        {Guardian.Support.TokenModule, :revoke,
+         [Guardian.PlugTest.Impl, bob_claims, bob_token, []]},
         {Guardian.PlugTest.Impl, :on_revoke, [bob_claims, bob_token, []]},
         {Guardian.PlugTest.Impl, :before_sign_out, [:conn, :jane, []]},
+        {Guardian.Support.TokenModule, :revoke,
+         [Guardian.PlugTest.Impl, jane_claims, jane_token, []]},
         {Guardian.PlugTest.Impl, :on_revoke, [jane_claims, jane_token, []]}
       ]
 


### PR DESCRIPTION
The README states that the Plug wrapped around Guardian should revoke tokens when calling `Guardian.Plug.sign_out(conn, opts)`. 

The hook was not actually called though. This PR adds calling the `:on_revoke` hook upon signing out user(s).

fixes #447 