### PR TITLE
Complement typespec for resource_from_token

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -425,7 +425,7 @@ defmodule Guardian do
               token :: Guardian.Token.token(),
               claims_to_check :: Guardian.Token.claims() | nil,
               opts :: Guardian.options()
-            ) :: {:ok, Guardian.Token.resource(), Guardian.Token.claims()}
+            ) :: {:ok, Guardian.Token.resource(), Guardian.Token.claims()} | {:error, any}
       def resource_from_token(token, claims_to_check \\ %{}, opts \\ []),
         do: Guardian.resource_from_token(__MODULE__, token, claims_to_check, opts)
 
@@ -634,7 +634,7 @@ defmodule Guardian do
           token :: Guardian.Token.token(),
           claims_to_check :: Guardian.Token.claims() | nil,
           opts :: options
-        ) :: {:ok, Guardian.Token.resource(), Guardian.Token.claims()}
+        ) :: {:ok, Guardian.Token.resource(), Guardian.Token.claims()} | {:error, any}
   def resource_from_token(mod, token, claims_to_check \\ %{}, opts \\ []) do
     with {:ok, claims} <- Guardian.decode_and_verify(mod, token, claims_to_check, opts),
          {:ok, resource} <- returning_tuple({mod, :resource_from_claims, [claims]}) do

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -249,6 +249,11 @@ defmodule GuardianTest do
       claims = ctx.claims
       assert {:ok, ^resource, ^claims} = Guardian.resource_from_token(ctx.impl, ctx.token, %{}, [])
     end
+
+    test "it returns an error when token can't be decoded", ctx do
+      invalid_token = -1
+      assert {:error, :invalid_token} = Guardian.resource_from_token(ctx.impl, invalid_token, %{}, [])
+    end
   end
 
   describe "revoke" do


### PR DESCRIPTION
During a project implementation I found out that the typespec for `Guardian.resource_from_token/3` and `Guardian.resource_from_token/4` is incomplete.

The current typespec only accounts for success case but when the token can't be decoded it returns `{:error, any}` from `Guardian.returning_tuple/1`.