### PR TITLE
Remove incorrect param in UserSocket example

### DIFF
--- a/upgrade_guides/0.14.to.1.0.md
+++ b/upgrade_guides/0.14.to.1.0.md
@@ -296,7 +296,7 @@ defmodule MyApp.UserSocket do
   use Guardian.Phoenix.Socket
   
   ## Channels
-  channel "user:*", MyApp.UserChannel, timeout: 45_000
+  channel "user:*", MyApp.UserChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket
@@ -317,7 +317,7 @@ defmodule MyApp.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  channel "user:*", MyApp.UserChannel, timeout: 45_000
+  channel "user:*", MyApp.UserChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket


### PR DESCRIPTION
I recently submitted a PR with an example how to migrate UserSocket to Guardian 1.0.

However, I noticed that I put one parameter in the wrong place (the `timeout` param is actually for the `transport`, no the `channel`). I decided to remove it altogether from the example, since it's an optional param that not everyone needs.