### PR TITLE
fix bug where other :guardian_ keys are parsed from the conn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v 1.1.0
 
 * JWT secret fetcher behaviour added
+* Let Guardian plug call :revoke on sign_out [#458](https://github.com/ueberauth/guardian/pull/458)
+* Fix an issue where Guardian.Plug tries to clear the wrong keys from the conn [#476](https://github.com/ueberauth/guardian/pull/476)
 
 # v 1.0.0
 

--- a/lib/guardian/plug/keys.ex
+++ b/lib/guardian/plug/keys.ex
@@ -30,13 +30,16 @@ defmodule Guardian.Plug.Keys do
   def base_key("guardian_" <> _ = the_key), do: String.to_atom(the_key)
   def base_key(the_key), do: String.to_atom("guardian_#{the_key}")
 
-  def key_from_other(other_key) do
-    other_key
-    |> to_string()
-    |> String.replace(~r/(_(token|resource|claims))?$/, "")
-    |> find_key_from_other()
+  def key_from_other(other_key) when is_binary(other_key) do
+    ~r/^guardian_(?<key>.+)_(token|resource|claims)$/
+    |> Regex.named_captures(other_key)
+    |> extract_key()
   end
-
-  defp find_key_from_other("guardian_" <> key), do: String.to_atom(key)
-  defp find_key_from_other(_), do: nil
+  def key_from_other(atom) do
+    atom
+    |> to_string()
+    |> key_from_other()
+  end
+  defp extract_key(%{"key" => key}), do: String.to_atom(key)
+  defp extract_key(_), do: nil
 end


### PR DESCRIPTION
Came accross a problem where other `:guardian_` keys where being processed by the `Guardian.Plug.Keys` module. Other meaning: other than `_claims`, `_token` and `_resource`.

These other keys may, for example, have been put there by another Plug in the pipeline. In particular, this causes problems when working together with `guardian_db` and revoking sessions. 

The test demonstrates this by constructing this:
```ex
conn.private == %{
  guardian_default_claims: %{"sub" => "bob", "typ" => "access"},
  guardian_default_resource: %{id: "bob"},
  guardian_default_token: "eyJjbGFpbXMiOnsidHlwIjoiYWNjZXNzIiwic3ViIjoiYm9iIn19",
  guardian_error_handler: Guardian.PlugTest.PipelineImpl.Handler,
  guardian_module: Guardian.PlugTest.PipelineImpl.Impl,
  plug_session: %{
    "guardian_default_token" => "eyJjbGFpbXMiOnsidHlwIjoiYWNjZXNzIiwic3ViIjoiYm9iIn19"
  },
  plug_session_fetch: :done,
  plug_session_info: :renew
}
```
and then calling `Impl.Plug.sign_out` which would subsequently not try to clear the key `:guardian_error_handler` from the session with this fix.