### PR TITLE
Fix sign_in usage

### DIFF
--- a/upgrade_guides/0.14.to.1.0.md
+++ b/upgrade_guides/0.14.to.1.0.md
@@ -182,13 +182,13 @@ When working with plugs, `sign_in`/`sign_out` are still with us but instead of u
 
 0.14.x
 ```elixir
-conn = Guardian.Plug.sign_in(conn, resource, [token_type, claims])
+conn = Guardian.Plug.sign_in(conn, resource, token_type, claims)
 conn = Guardian.Plug.sign_out(conn, token, [claims_to_check])
 ```
 
 1.0
 ```elixir
-conn = MyApp.Guardian.Plug.sign_in(conn, resource, [claims, opts])
+conn = MyApp.Guardian.Plug.sign_in(conn, resource, claims, opts)
 conn = MyApp.Guardian.Plug.sign_out(conn, resource, [claims_to_check, opts])
 ```
 


### PR DESCRIPTION
`sign_in` should take claims map and opts keyword list as two separate arguments, s. https://github.com/ueberauth/guardian/blob/master/lib/guardian/plug.ex#L76 and https://github.com/ueberauth/guardian/blob/master/lib/guardian/plug.ex#L176.

Not sure about `sign_out`, but I think it only takes opts and no claims https://github.com/ueberauth/guardian/blob/master/lib/guardian/plug.ex#L79 so that call has to be changed to `conn = MyApp.Guardian.Plug.sign_out(conn, resource, opts)`.