### PR TITLE
Fix upgrade docs load resource allow blank option

### DIFF
--- a/guides/upgrading/v1.0.md
+++ b/guides/upgrading/v1.0.md
@@ -212,7 +212,7 @@ defmodule MyApp.Guardian.AuthPipeline do
   plug Guardian.Plug.VerifySession, claims: @claims
   plug Guardian.Plug.VerifyHeader, claims: @claims, realm: "Bearer"
   plug Guardian.Plug.EnsureAuthenticated
-  plug Guardian.Plug.LoadResource, ensure: true
+  plug Guardian.Plug.LoadResource, allow_blank: false
 end
 ```
 


### PR DESCRIPTION
It seems in 1.0 to ensure the resource found is not nil the option is `allow_blank` right? I cannot find any reference of the `ensure` option