### PR TITLE
Remove Sentinel from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,6 @@ end
 ## Related projects
 
 * [GuardianDb](https://hex.pm/packages/guardian_db) - Token tracking in the database
-* [Sentinel](https://hex.pm/packages/sentinel) - Adds helpful extras to Guardian like default mailer support, as well as out of the box controllers and routes
 * [sans_password](https://hex.pm/packages/sans_password) - A simple, passwordless authentication system based on Guardian.
 * [protego](https://hex.pm/packages/protego) - Flexible authentication solution for Elixir/Phoenix with Guardian.
 


### PR DESCRIPTION
Since Sentinel has a deprecation notice on it's github page this commit removes it from the Related Projects section of the readme.

Another option would be to simple add a `deprecated` warning on the readme and keep it there. If this is a more desirable option please give me a heads up and I will update the PR 😉 

![image](https://user-images.githubusercontent.com/13217785/41211977-419c9ce0-6d11-11e8-8248-4f2bb026307c.png)