### PR TITLE
change uuid to elixir_uuid

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Guardian.Mixfile do
   defp elixirc_paths(_), do: ["lib"]
 
   def application do
-    [applications: [:logger, :poison, :jose, :uuid]]
+    [applications: [:logger, :poison, :jose, :elixir_uuid]]
   end
 
   def docs do
@@ -140,7 +140,7 @@ defmodule Guardian.Mixfile do
     [
       {:jose, "~> 1.8"},
       {:poison, "~> 2.2 or ~> 3.0"},
-      {:uuid, ">= 1.1.1"},
+      { :elixir_uuid, "~> 1.2" },
 
       # Optional dependencies
       {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -140,7 +140,7 @@ defmodule Guardian.Mixfile do
     [
       {:jose, "~> 1.8"},
       {:poison, "~> 2.2 or ~> 3.0"},
-      { :elixir_uuid, "~> 1.2" },
+      {:elixir_uuid, "~> 1.2"},
 
       # Optional dependencies
       {:phoenix, "~> 1.0 or ~> 1.2 or ~> 1.3", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,7 @@
   "credo": {:hex, :credo, "0.9.2", "841d316612f568beb22ba310d816353dddf31c2d94aa488ae5a27bb53760d0bf", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.8.2", "b941a08a1842d7aa629e0bbc969186a4cefdd035bad9fe15d43aaaaaeb8fae36", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
the uuid package has been renamed to elixir_uuid in order to avoid collision with other applications that use the same name