### PR TITLE
Updating context module name

### DIFF
--- a/guides/tutorial/start-tutorial.md
+++ b/guides/tutorial/start-tutorial.md
@@ -137,7 +137,7 @@ defp put_password_hash(changeset), do: changeset
 Now we need a way to verify the username/password credentials.
 
 ```elixir
-## lib/auth_me/user_manager.ex
+## lib/auth_me/user_manager/user_manager.ex
 
 alias Comeonin.Bcrypt
 

--- a/guides/tutorial/start-tutorial.md
+++ b/guides/tutorial/start-tutorial.md
@@ -58,7 +58,7 @@ For more information please reference the [implementation module docs](introduct
 You can have as many implementation modules as you need to depending on your application. For this one though we only have a simple user system so we'll only need one.
 
 ```elixir
-## lib/auth_me/auth/guardian.ex
+## lib/auth_me/user_manager/guardian.ex
 
 defmodule AuthMe.UserManager.Guardian do
   use Guardian, otp_app: :auth_me
@@ -116,7 +116,7 @@ We added `:comeonin` and `:bcrypt_elixir` to our mix deps at the start. We're go
 2. When verifying the login credentials
 
 ```elixir
-## lib/auth_me/auth/user.ex
+## lib/auth_me/user_manager/user.ex
 
 alias Comeonin.Bcrypt
 
@@ -137,7 +137,7 @@ defp put_password_hash(changeset), do: changeset
 Now we need a way to verify the username/password credentials.
 
 ```elixir
-## lib/auth_me/auth.ex
+## lib/auth_me/user_manager.ex
 
 alias Comeonin.Bcrypt
 
@@ -170,7 +170,7 @@ Please read the [pipeline guide](plug-pipeline.html) for more information.
 We want our pipeline to look after session and header authentication (where to look for the token), load the resource but not enforce it. By not enforcing it we can have a "logged in" or "maybe logged in". We can use the [Guardian.Plug.EnsureAuthenticated](Guardian.Plug.EnsureAuthenticated.html) plug for those cases where we must have a logged in resource by using Phoenix pipelines in the router.
 
 ```elixir
-## lib/auth_me/auth/pipeline.ex
+## lib/auth_me/user_manager/pipeline.ex
 
 defmodule AuthMe.UserManager.Pipeline do
   use Guardian.Plug.Pipeline,
@@ -190,7 +190,7 @@ end
 We'll also need the error handler referenced in our pipeline to handle the case where there was a failure to authenticate.
 
 ```elixir
-## lib/auth_me/auth/error_handler.ex
+## lib/auth_me/user_manager/error_handler.ex
 
 defmodule AuthMe.UserManager.ErrorHandler do
   import Plug.Conn


### PR DESCRIPTION
In a previous version of this document the "UserManager" context was named "Auth". This commit updates some directories and file names to reflect that change.