### PR TITLE
Add hours to ttl type.

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -685,6 +685,7 @@ defmodule Guardian do
   * `:second` | `:seconds`
   * `:minute` | `:minutes`
   * `:hour` | `:hours`
+  * `:day` | `:days`
   * `:week` | `:weeks`
 
   See documentation for your token module for other options.

--- a/lib/guardian/token.ex
+++ b/lib/guardian/token.ex
@@ -13,6 +13,8 @@ defmodule Guardian.Token do
           | {pos_integer, :seconds}
           | {pos_integer, :minute}
           | {pos_integer, :minutes}
+          | {pos_integer, :hour}
+          | {pos_integer, :hours}
           | {pos_integer, :day}
           | {pos_integer, :days}
           | {pos_integer, :week}


### PR DESCRIPTION
`:day/:days` are also valid but were missing from the docs in `guardian.ex`