### PR TITLE
Update credo rules and remove GPlug and friends aliases.

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -47,82 +47,101 @@
       #     {Credo.Check.Design.DuplicatedCode, false}
       #
       checks: [
-        {Credo.Check.Consistency.ExceptionNames},
-        {Credo.Check.Consistency.LineEndings},
-        {Credo.Check.Consistency.ParameterPatternMatching},
-        {Credo.Check.Consistency.SpaceAroundOperators},
-        {Credo.Check.Consistency.SpaceInParentheses},
-        {Credo.Check.Consistency.TabsOrSpaces},
+        #
+        ## Consistency Checks
+        #
+        {Credo.Check.Consistency.ExceptionNames, []},
+        {Credo.Check.Consistency.LineEndings, []},
+        {Credo.Check.Consistency.ParameterPatternMatching, []},
+        {Credo.Check.Consistency.SpaceAroundOperators, []},
+        {Credo.Check.Consistency.SpaceInParentheses, []},
+        {Credo.Check.Consistency.TabsOrSpaces, []},
 
-        # For some checks, like AliasUsage, you can only customize the priority
+        #
+        ## Design Checks
+        #
+        # You can customize the priority of any check
         # Priority values are: `low, normal, high, higher`
-        {Credo.Check.Design.AliasUsage, priority: :low, if_called_more_often_than: 2},
-
-        # For others you can set parameters
-
-        # If you don't want the `setup` and `test` macro calls in ExUnit tests
-        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
-        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
-        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
-
+        #
+        {Credo.Check.Design.AliasUsage,
+         [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 1]},
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
-        {Credo.Check.Design.TagTODO, exit_status: 2},
-        {Credo.Check.Design.TagFIXME},
+        #
+        {Credo.Check.Design.TagTODO, [exit_status: 2]},
+        {Credo.Check.Design.TagFIXME, []},
 
-        {Credo.Check.Readability.FunctionNames},
-        {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
-        {Credo.Check.Readability.ModuleAttributeNames},
-        {Credo.Check.Readability.ModuleDoc},
-        {Credo.Check.Readability.ModuleNames},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
-        {Credo.Check.Readability.ParenthesesInCondition},
-        {Credo.Check.Readability.PredicateFunctionNames},
-        {Credo.Check.Readability.PreferImplicitTry},
-        {Credo.Check.Readability.RedundantBlankLines},
-        {Credo.Check.Readability.StringSigils},
-        {Credo.Check.Readability.TrailingBlankLine},
-        {Credo.Check.Readability.TrailingWhiteSpace},
-        {Credo.Check.Readability.VariableNames},
-        {Credo.Check.Readability.Semicolons},
-        {Credo.Check.Readability.SpaceAfterCommas},
+        #
+        ## Readability Checks
+        #
+        {Credo.Check.Readability.AliasOrder, []},
+        {Credo.Check.Readability.FunctionNames, []},
+        {Credo.Check.Readability.LargeNumbers, []},
+        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+        {Credo.Check.Readability.ModuleAttributeNames, []},
+        {Credo.Check.Readability.ModuleDoc, []},
+        {Credo.Check.Readability.ModuleNames, []},
+        {Credo.Check.Readability.ParenthesesInCondition, []},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+        {Credo.Check.Readability.PredicateFunctionNames, []},
+        {Credo.Check.Readability.PreferImplicitTry, []},
+        {Credo.Check.Readability.RedundantBlankLines, []},
+        {Credo.Check.Readability.Semicolons, []},
+        {Credo.Check.Readability.SpaceAfterCommas, []},
+        {Credo.Check.Readability.StringSigils, []},
+        {Credo.Check.Readability.TrailingBlankLine, []},
+        {Credo.Check.Readability.TrailingWhiteSpace, []},
+        {Credo.Check.Readability.VariableNames, []},
 
-        {Credo.Check.Refactor.DoubleBooleanNegation},
-        {Credo.Check.Refactor.CondStatements},
-        {Credo.Check.Refactor.CyclomaticComplexity},
-        {Credo.Check.Refactor.FunctionArity},
-        {Credo.Check.Refactor.LongQuoteBlocks},
-        {Credo.Check.Refactor.MatchInCondition},
-        {Credo.Check.Refactor.NegatedConditionsInUnless},
-        {Credo.Check.Refactor.NegatedConditionsWithElse},
-        {Credo.Check.Refactor.Nesting},
-        {Credo.Check.Refactor.PipeChainStart},
-        {Credo.Check.Refactor.UnlessWithElse},
+        #
+        ## Refactoring Opportunities
+        #
+        {Credo.Check.Refactor.CondStatements, []},
+        {Credo.Check.Refactor.CyclomaticComplexity, []},
+        {Credo.Check.Refactor.FunctionArity, []},
+        {Credo.Check.Refactor.LongQuoteBlocks, []},
+        {Credo.Check.Refactor.MapInto, []},
+        {Credo.Check.Refactor.MatchInCondition, []},
+        {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+        {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+        {Credo.Check.Refactor.Nesting, []},
+        {Credo.Check.Refactor.PipeChainStart,
+         [excluded_argument_types: [:atom, :binary, :fn, :keyword], excluded_functions: []]},
+        {Credo.Check.Refactor.UnlessWithElse, []},
 
-        {Credo.Check.Warning.BoolOperationOnSameValues},
-        {Credo.Check.Warning.IExPry},
-        {Credo.Check.Warning.IoInspect},
-        {Credo.Check.Warning.LazyLogging},
-        {Credo.Check.Warning.OperationOnSameValues},
-        {Credo.Check.Warning.OperationWithConstantResult},
-        {Credo.Check.Warning.UnusedEnumOperation},
-        {Credo.Check.Warning.UnusedFileOperation},
-        {Credo.Check.Warning.UnusedKeywordOperation},
-        {Credo.Check.Warning.UnusedListOperation},
-        {Credo.Check.Warning.UnusedPathOperation},
-        {Credo.Check.Warning.UnusedRegexOperation},
-        {Credo.Check.Warning.UnusedStringOperation},
-        {Credo.Check.Warning.UnusedTupleOperation},
+        #
+        ## Warnings
+        #
+        {Credo.Check.Warning.BoolOperationOnSameValues, []},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+        {Credo.Check.Warning.IExPry, []},
+        {Credo.Check.Warning.IoInspect, []},
+        {Credo.Check.Warning.LazyLogging, []},
+        {Credo.Check.Warning.OperationOnSameValues, []},
+        {Credo.Check.Warning.OperationWithConstantResult, []},
+        {Credo.Check.Warning.RaiseInsideRescue, []},
+        {Credo.Check.Warning.UnusedEnumOperation, []},
+        {Credo.Check.Warning.UnusedFileOperation, []},
+        {Credo.Check.Warning.UnusedKeywordOperation, []},
+        {Credo.Check.Warning.UnusedListOperation, []},
+        {Credo.Check.Warning.UnusedPathOperation, []},
+        {Credo.Check.Warning.UnusedRegexOperation, []},
+        {Credo.Check.Warning.UnusedStringOperation, []},
+        {Credo.Check.Warning.UnusedTupleOperation, []},
 
+        #
         # Controversial and experimental checks (opt-in, just remove `, false`)
         #
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+        {Credo.Check.Design.DuplicatedCode, false},
+        {Credo.Check.Readability.Specs, false},
         {Credo.Check.Refactor.ABCSize, false},
         {Credo.Check.Refactor.AppendSingleItem, false},
+        {Credo.Check.Refactor.DoubleBooleanNegation, false},
         {Credo.Check.Refactor.VariableRebinding, false},
         {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+        {Credo.Check.Warning.UnsafeToAtom, false}
 
         # Custom checks can be created using `mix credo.gen.check`.
         #

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -321,8 +321,6 @@ defmodule Guardian do
   end
 
   defmacro __using__(opts \\ []) do
-    alias Guardian.Config, as: GConfig
-
     otp_app = Keyword.get(opts, :otp_app)
 
     # credo:disable-for-next-line Credo.Check.Refactor.LongQuoteBlocks
@@ -348,9 +346,11 @@ defmodule Guardian do
       @config fn ->
         the_otp_app |> Application.get_env(__MODULE__, []) |> Keyword.merge(the_opts)
       end
-      @config_with_key fn key -> @config.() |> Keyword.get(key) |> GConfig.resolve_value() end
+      @config_with_key fn key ->
+        @config.() |> Keyword.get(key) |> Guardian.Config.resolve_value()
+      end
       @config_with_key_and_default fn key, default ->
-        @config.() |> Keyword.get(key, default) |> GConfig.resolve_value()
+        @config.() |> Keyword.get(key, default) |> Guardian.Config.resolve_value()
       end
 
       @doc """
@@ -379,7 +379,7 @@ defmodule Guardian do
 
       @spec config(atom | String.t(), any) :: any
       def config(key, default \\ nil),
-        do: config() |> Keyword.get(key, default) |> GConfig.resolve_value()
+        do: config() |> Keyword.get(key, default) |> Guardian.Config.resolve_value()
 
       @doc """
       Provides the content of the token but without verification

--- a/lib/guardian/phoenix/socket.ex
+++ b/lib/guardian/phoenix/socket.ex
@@ -52,7 +52,6 @@ if Code.ensure_loaded?(Phoenix) do
 
     import Guardian.Plug.Keys
 
-    alias Guardian.Plug, as: GPlug
     alias Phoenix.Socket
 
     @doc """
@@ -176,7 +175,7 @@ if Code.ensure_loaded?(Phoenix) do
     def authenticate(socket, impl, token, claims_to_check, opts) do
       with {:ok, resource, claims} <-
              Guardian.resource_from_token(impl, token, claims_to_check, opts),
-           key <- Keyword.get(opts, :key, GPlug.default_key()) do
+           key <- Keyword.get(opts, :key, Guardian.Plug.default_key()) do
         authed_socket = assign_rtc(socket, resource, token, claims, key)
 
         {:ok, authed_socket}

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -48,7 +48,6 @@ if Code.ensure_loaded?(Plug) do
     import Guardian.Plug.Keys
     import Plug.Conn
 
-    alias Guardian.Plug, as: GPlug
     alias Guardian.Plug.Pipeline
 
     alias __MODULE__.UnauthenticatedError
@@ -58,32 +57,32 @@ if Code.ensure_loaded?(Plug) do
         def implementation, do: unquote(impl)
 
         def put_current_token(conn, token, opts \\ []),
-          do: GPlug.put_current_token(conn, token, opts)
+          do: Guardian.Plug.put_current_token(conn, token, opts)
 
         def put_current_claims(conn, claims, opts \\ []),
-          do: GPlug.put_current_claims(conn, claims, opts)
+          do: Guardian.Plug.put_current_claims(conn, claims, opts)
 
         def put_current_resource(conn, resource, opts \\ []),
-          do: GPlug.put_current_resource(conn, resource, opts)
+          do: Guardian.Plug.put_current_resource(conn, resource, opts)
 
-        def current_token(conn, opts \\ []), do: GPlug.current_token(conn, opts)
+        def current_token(conn, opts \\ []), do: Guardian.Plug.current_token(conn, opts)
 
-        def current_claims(conn, opts \\ []), do: GPlug.current_claims(conn, opts)
+        def current_claims(conn, opts \\ []), do: Guardian.Plug.current_claims(conn, opts)
 
-        def current_resource(conn, opts \\ []), do: GPlug.current_resource(conn, opts)
+        def current_resource(conn, opts \\ []), do: Guardian.Plug.current_resource(conn, opts)
 
-        def authenticated?(conn, opts \\ []), do: GPlug.authenticated?(conn, opts)
+        def authenticated?(conn, opts \\ []), do: Guardian.Plug.authenticated?(conn, opts)
 
         def sign_in(conn, resource, claims \\ %{}, opts \\ []),
-          do: GPlug.sign_in(conn, implementation(), resource, claims, opts)
+          do: Guardian.Plug.sign_in(conn, implementation(), resource, claims, opts)
 
-        def sign_out(conn, opts \\ []), do: GPlug.sign_out(conn, implementation(), opts)
+        def sign_out(conn, opts \\ []), do: Guardian.Plug.sign_out(conn, implementation(), opts)
 
         def remember_me(conn, resource, claims \\ %{}, opts \\ []),
-          do: GPlug.remember_me(conn, implementation(), resource, claims, opts)
+          do: Guardian.Plug.remember_me(conn, implementation(), resource, claims, opts)
 
         def remember_me_from_token(conn, token, claims \\ %{}, opts \\ []),
-          do: GPlug.remember_me_from_token(conn, implementation(), token, claims, opts)
+          do: Guardian.Plug.remember_me_from_token(conn, implementation(), token, claims, opts)
       end
     end
 

--- a/lib/guardian/plug/load_resource.ex
+++ b/lib/guardian/plug/load_resource.ex
@@ -36,7 +36,6 @@ if Code.ensure_loaded?(Plug) do
 
     import Plug.Conn
 
-    alias Guardian.Plug, as: GPlug
     alias Guardian.Plug.Pipeline
 
     @behaviour Plug
@@ -51,7 +50,7 @@ if Code.ensure_loaded?(Plug) do
       allow_blank = Keyword.get(opts, :allow_blank)
 
       conn
-      |> GPlug.current_claims(opts)
+      |> Guardian.Plug.current_claims(opts)
       |> resource(conn, opts)
       |> respond(allow_blank)
     end
@@ -72,7 +71,7 @@ if Code.ensure_loaded?(Plug) do
     defp respond({:error, reason, conn, opts}, _), do: return_error(conn, reason, opts)
 
     defp respond({:ok, resource, conn, opts}, _),
-      do: GPlug.put_current_resource(conn, resource, opts)
+      do: Guardian.Plug.put_current_resource(conn, resource, opts)
 
     defp return_error(conn, reason, opts) do
       handler = Pipeline.fetch_error_handler!(conn, opts)

--- a/lib/guardian/plug/pipeline.ex
+++ b/lib/guardian/plug/pipeline.ex
@@ -109,8 +109,6 @@ if Code.ensure_loaded?(Plug) do
 
     import Plug.Conn
 
-    alias Guardian.Plug, as: GPlug
-
     @doc """
     Create your very own `Guardian.Plug.Pipeline`
 
@@ -123,8 +121,6 @@ if Code.ensure_loaded?(Plug) do
 
       quote do
         use Plug.Builder
-        alias Guardian.Config, as: GConfig
-        alias Guardian.Plug, as: GPlug
 
         import Pipeline
 
@@ -158,14 +154,14 @@ if Code.ensure_loaded?(Plug) do
           |> Keyword.merge(opts)
           |> config()
           |> Keyword.get(key)
-          |> GConfig.resolve_value()
+          |> Guardian.Config.resolve_value()
         end
 
         defp put_modules(conn, opts) do
           pipeline_opts = [
             module: config(opts, :module),
             error_handler: config(opts, :error_handler),
-            key: config(opts, :key, GPlug.default_key())
+            key: config(opts, :key, Guardian.Plug.default_key())
           ]
 
           Pipeline.call(conn, pipeline_opts)
@@ -204,7 +200,7 @@ if Code.ensure_loaded?(Plug) do
     def current_error_handler(conn), do: conn.private[:guardian_error_handler]
 
     def fetch_key(conn, opts),
-      do: Keyword.get(opts, :key, current_key(conn)) || GPlug.default_key()
+      do: Keyword.get(opts, :key, current_key(conn)) || Guardian.Plug.default_key()
 
     def fetch_module(conn, opts), do: Keyword.get(opts, :module, current_module(conn))
 

--- a/lib/guardian/plug/verify_cookie.ex
+++ b/lib/guardian/plug/verify_cookie.ex
@@ -43,7 +43,6 @@ if Code.ensure_loaded?(Plug) do
     import Plug.Conn
     import Guardian.Plug.Keys
 
-    alias Guardian.Plug, as: GPlug
     alias Guardian.Plug.Pipeline
 
     @behaviour Plug
@@ -61,19 +60,19 @@ if Code.ensure_loaded?(Plug) do
     end
 
     def call(conn, opts) do
-      with nil <- GPlug.current_token(conn, opts),
+      with nil <- Guardian.Plug.current_token(conn, opts),
            {:ok, token} <- find_token_from_cookies(conn, opts),
            module <- Pipeline.fetch_module!(conn, opts),
            key <- storage_key(conn, opts),
            exchange_from <- Keyword.get(opts, :exchange_from, "refresh"),
            default_type <- module.default_token_type(),
            exchange_to <- Keyword.get(opts, :exchange_to, default_type),
-           active_session? <- GPlug.session_active?(conn),
+           active_session? <- Guardian.Plug.session_active?(conn),
            {:ok, _old, {new_t, new_c}} <-
              Guardian.exchange(module, token, exchange_from, exchange_to, opts) do
         conn
-        |> GPlug.put_current_token(new_t, key: key)
-        |> GPlug.put_current_claims(new_c, key: key)
+        |> Guardian.Plug.put_current_token(new_t, key: key)
+        |> Guardian.Plug.put_current_claims(new_c, key: key)
         |> maybe_put_in_session(active_session?, new_t, opts)
       else
         :no_token_found ->

--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -55,7 +55,6 @@ if Code.ensure_loaded?(Plug) do
     `MyApp.ImplementationModule.current_token` and `MyApp.ImplementationModule.current_claims`
     """
 
-    alias Guardian.Plug, as: GPlug
     alias Guardian.Plug.Pipeline
 
     import Plug.Conn
@@ -83,15 +82,15 @@ if Code.ensure_loaded?(Plug) do
     @impl Plug
     @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
     def call(conn, opts) do
-      with nil <- GPlug.current_token(conn, opts),
+      with nil <- Guardian.Plug.current_token(conn, opts),
            {:ok, token} <- fetch_token_from_header(conn, opts),
            module <- Pipeline.fetch_module!(conn, opts),
            claims_to_check <- Keyword.get(opts, :claims, %{}),
            key <- storage_key(conn, opts),
            {:ok, claims} <- Guardian.decode_and_verify(module, token, claims_to_check, opts) do
         conn
-        |> GPlug.put_current_token(token, key: key)
-        |> GPlug.put_current_claims(claims, key: key)
+        |> Guardian.Plug.put_current_token(token, key: key)
+        |> Guardian.Plug.put_current_claims(claims, key: key)
       else
         :no_token_found ->
           conn

--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -30,7 +30,6 @@ if Code.ensure_loaded?(Plug) do
     import Plug.Conn
     import Guardian.Plug.Keys
 
-    alias Guardian.Plug, as: GPlug
     alias Guardian.Plug.Pipeline
 
     @behaviour Plug
@@ -42,7 +41,7 @@ if Code.ensure_loaded?(Plug) do
     @impl Plug
     @spec call(conn :: Plug.Conn.t(), opts :: Keyword.t()) :: Plug.Conn.t()
     def call(conn, opts) do
-      if GPlug.session_active?(conn) do
+      if Guardian.Plug.session_active?(conn) do
         verify_session(conn, opts)
       else
         conn
@@ -50,15 +49,15 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp verify_session(conn, opts) do
-      with nil <- GPlug.current_token(conn, opts),
+      with nil <- Guardian.Plug.current_token(conn, opts),
            {:ok, token} <- find_token_from_session(conn, opts),
            module <- Pipeline.fetch_module!(conn, opts),
            claims_to_check <- Keyword.get(opts, :claims, %{}),
            key <- storage_key(conn, opts),
            {:ok, claims} <- Guardian.decode_and_verify(module, token, claims_to_check, opts) do
         conn
-        |> GPlug.put_current_token(token, key: key)
-        |> GPlug.put_current_claims(claims, key: key)
+        |> Guardian.Plug.put_current_token(token, key: key)
+        |> Guardian.Plug.put_current_claims(claims, key: key)
       else
         :no_token_found ->
           conn

--- a/lib/guardian/token/jwt.ex
+++ b/lib/guardian/token/jwt.ex
@@ -173,12 +173,15 @@ defmodule Guardian.Token.Jwt do
 
     defmacro __using__(_opts \\ []) do
       quote do
-        alias Guardian.Token.Jwt.SecretFetcher.SecretFetcherDefaultImpl, as: DI
+        alias Guardian.Token.Jwt.SecretFetcher.SecretFetcherDefaultImpl
 
-        def fetch_signing_secret(mod, opts), do: DI.fetch_signing_secret(mod, opts)
+        def fetch_signing_secret(mod, opts) do
+          SecretFetcherDefaultImpl.fetch_signing_secret(mod, opts)
+        end
 
-        def fetch_verifying_secret(mod, token_headers, opts),
-          do: DI.fetch_verifying_secret(mod, token_headers, opts)
+        def fetch_verifying_secret(mod, token_headers, opts) do
+          SecretFetcherDefaultImpl.fetch_verifying_secret(mod, token_headers, opts)
+        end
 
         defoverridable fetch_signing_secret: 2, fetch_verifying_secret: 3
       end

--- a/test/guardian/plug/ensure_authenticated_test.exs
+++ b/test/guardian/plug/ensure_authenticated_test.exs
@@ -4,7 +4,6 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
   use Plug.Test
   use ExUnit.Case
 
-  alias Guardian.Plug, as: GPlug
   alias Guardian.Plug.EnsureAuthenticated
 
   defmodule Handler do
@@ -54,8 +53,8 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
     setup ctx do
       conn =
         ctx.conn
-        |> GPlug.put_current_token(ctx.token, [])
-        |> GPlug.put_current_claims(ctx.claims, [])
+        |> Guardian.Plug.put_current_token(ctx.token, [])
+        |> Guardian.Plug.put_current_claims(ctx.claims, [])
 
       {:ok, %{conn: conn}}
     end

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -4,8 +4,7 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
   use Plug.Test
   use ExUnit.Case, async: true
 
-  alias Guardian.Plug, as: GPlug
-  alias GPlug.{EnsureNotAuthenticated}
+  alias Guardian.Plug.EnsureNotAuthenticated
 
   @resource %{id: "bobby"}
 
@@ -47,8 +46,8 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
     setup ctx do
       conn =
         ctx.conn
-        |> GPlug.put_current_token(ctx.token, [])
-        |> GPlug.put_current_claims(ctx.claims, [])
+        |> Guardian.Plug.put_current_token(ctx.token, [])
+        |> Guardian.Plug.put_current_claims(ctx.claims, [])
 
       {:ok, %{conn: conn}}
     end

--- a/test/guardian/plug/load_resource_test.exs
+++ b/test/guardian/plug/load_resource_test.exs
@@ -4,8 +4,7 @@ defmodule Guardian.Plug.LoadResourceTest do
   use Plug.Test
   use ExUnit.Case, async: true
 
-  alias Guardian.Plug, as: GPlug
-  alias GPlug.{LoadResource}
+  alias Guardian.Plug.LoadResource
 
   @resource %{id: "bobby"}
 
@@ -70,8 +69,8 @@ defmodule Guardian.Plug.LoadResourceTest do
     setup %{conn: conn, token: token} do
       conn =
         conn
-        |> GPlug.put_current_token(token, [])
-        |> GPlug.put_current_claims(%{"no" => "sub"}, [])
+        |> Guardian.Plug.put_current_token(token, [])
+        |> Guardian.Plug.put_current_claims(%{"no" => "sub"}, [])
 
       {:ok, conn: conn}
     end
@@ -87,15 +86,15 @@ defmodule Guardian.Plug.LoadResourceTest do
     test "it lets the connection continue and adds the resource", ctx do
       conn =
         ctx.conn
-        |> GPlug.put_current_token(ctx.token, [])
-        |> GPlug.put_current_claims(ctx.claims, [])
+        |> Guardian.Plug.put_current_token(ctx.token, [])
+        |> Guardian.Plug.put_current_claims(ctx.claims, [])
 
       conn = LoadResource.call(conn, module: ctx.impl, error_handler: ctx.handler)
 
       refute conn.status == 401
       refute conn.halted
 
-      assert @resource == GPlug.current_resource(conn, [])
+      assert @resource == Guardian.Plug.current_resource(conn, [])
     end
   end
 end

--- a/test/guardian/plug/verify_cookie_test.exs
+++ b/test/guardian/plug/verify_cookie_test.exs
@@ -3,8 +3,9 @@ defmodule Guardian.Plug.VerifyCookieTest do
 
   use Plug.Test
 
-  alias Guardian.Plug, as: GPlug
-  alias GPlug.{VerifyCookie, VerifySession, Pipeline}
+  alias Guardian.Plug.Pipeline
+  alias Guardian.Plug.VerifyCookie
+  alias Guardian.Plug.VerifySession
 
   use ExUnit.Case, async: true
 
@@ -47,8 +48,8 @@ defmodule Guardian.Plug.VerifyCookieTest do
   test "with no cookies fetched it does nothing", ctx do
     conn = VerifyCookie.call(ctx.conn, [])
     refute conn.halted
-    refute GPlug.current_token(conn, [])
-    refute GPlug.current_claims(conn, [])
+    refute Guardian.Plug.current_token(conn, [])
+    refute Guardian.Plug.current_claims(conn, [])
   end
 
   describe "with fetched cookies that are empty" do
@@ -60,8 +61,8 @@ defmodule Guardian.Plug.VerifyCookieTest do
     test "it does nothing", ctx do
       conn = VerifyCookie.call(ctx.conn, [])
       refute conn.halted
-      refute GPlug.current_token(conn, [])
-      refute GPlug.current_claims(conn, [])
+      refute Guardian.Plug.current_token(conn, [])
+      refute Guardian.Plug.current_claims(conn, [])
     end
   end
 
@@ -80,13 +81,13 @@ defmodule Guardian.Plug.VerifyCookieTest do
     test "with an existing token already found", ctx do
       conn =
         ctx.conn
-        |> GPlug.put_current_token(ctx.token)
-        |> GPlug.put_current_claims(ctx.claims)
+        |> Guardian.Plug.put_current_token(ctx.token)
+        |> Guardian.Plug.put_current_claims(ctx.claims)
 
       conn = VerifyCookie.call(conn, [])
       refute conn.halted
-      assert GPlug.current_token(conn, []) == ctx.token
-      assert GPlug.current_claims(conn, []) == ctx.claims
+      assert Guardian.Plug.current_token(conn, []) == ctx.token
+      assert Guardian.Plug.current_claims(conn, []) == ctx.claims
     end
 
     test "with an incorrect token type", ctx do
@@ -99,11 +100,11 @@ defmodule Guardian.Plug.VerifyCookieTest do
       conn = VerifyCookie.call(ctx.conn, [])
 
       refute conn.halted
-      refute GPlug.current_token(conn, []) == ctx.token
-      refute GPlug.current_claims(conn, []) == ctx.claims
+      refute Guardian.Plug.current_token(conn, []) == ctx.token
+      refute Guardian.Plug.current_claims(conn, []) == ctx.claims
 
-      new_t = GPlug.current_token(conn, [])
-      new_c = GPlug.current_claims(conn, [])
+      new_t = Guardian.Plug.current_token(conn, [])
+      new_c = Guardian.Plug.current_claims(conn, [])
 
       assert new_c["typ"] == "access"
       refute new_t == ctx.token
@@ -121,11 +122,11 @@ defmodule Guardian.Plug.VerifyCookieTest do
       conn = VerifyCookie.call(conn, encode_from: "refresh", key: :secret)
 
       refute conn.halted
-      refute GPlug.current_token(conn, key: :secret) == ctx.token
-      refute GPlug.current_claims(conn, key: :secret) == ctx.claims
+      refute Guardian.Plug.current_token(conn, key: :secret) == ctx.token
+      refute Guardian.Plug.current_claims(conn, key: :secret) == ctx.claims
 
-      new_t = GPlug.current_token(conn, key: :secret)
-      new_c = GPlug.current_claims(conn, key: :secret)
+      new_t = Guardian.Plug.current_token(conn, key: :secret)
+      new_c = Guardian.Plug.current_claims(conn, key: :secret)
 
       assert new_c["typ"] == "access"
       refute new_t == ctx.token

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -3,8 +3,8 @@ defmodule Guardian.Plug.VerifyHeaderTest do
 
   use Plug.Test
 
-  alias Guardian.Plug, as: GPlug
-  alias GPlug.{VerifyHeader, Pipeline}
+  alias Guardian.Plug.Pipeline
+  alias Guardian.Plug.VerifyHeader
 
   use ExUnit.Case, async: true
 
@@ -48,8 +48,8 @@ defmodule Guardian.Plug.VerifyHeaderTest do
     conn = :get |> conn("/") |> VerifyHeader.call([])
 
     refute conn.status == 401
-    assert GPlug.current_token(conn, []) == nil
-    assert GPlug.current_claims(conn, []) == nil
+    assert Guardian.Plug.current_token(conn, []) == nil
+    assert Guardian.Plug.current_claims(conn, []) == nil
   end
 
   test "it uses the module from options", ctx do
@@ -60,8 +60,8 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       |> VerifyHeader.call(module: ctx.impl)
 
     refute conn.status == 401
-    assert GPlug.current_token(conn, []) == ctx.token
-    assert GPlug.current_claims(conn, []) == ctx.claims
+    assert Guardian.Plug.current_token(conn, []) == ctx.token
+    assert Guardian.Plug.current_claims(conn, []) == ctx.claims
   end
 
   test "it finds the module from the pipeline", ctx do
@@ -73,8 +73,8 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       |> VerifyHeader.call([])
 
     refute conn.status == 401
-    assert GPlug.current_token(conn, []) == ctx.token
-    assert GPlug.current_claims(conn, []) == ctx.claims
+    assert Guardian.Plug.current_token(conn, []) == ctx.token
+    assert Guardian.Plug.current_claims(conn, []) == ctx.claims
   end
 
   test "with an existing token on the connection it leaves it intact", ctx do
@@ -84,13 +84,13 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       :get
       |> conn("/")
       |> put_req_header("authorization", ctx.token)
-      |> GPlug.put_current_token(token)
-      |> GPlug.put_current_claims(claims)
+      |> Guardian.Plug.put_current_token(token)
+      |> Guardian.Plug.put_current_claims(claims)
       |> VerifyHeader.call([])
 
     refute conn.status == 401
-    assert GPlug.current_token(conn) == token
-    assert GPlug.current_claims(conn) == claims
+    assert Guardian.Plug.current_token(conn) == token
+    assert Guardian.Plug.current_claims(conn) == claims
   end
 
   test "with no module", ctx do
@@ -109,11 +109,11 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       |> put_req_header("authorization", ctx.token)
       |> VerifyHeader.call(module: ctx.impl, key: :secret)
 
-    refute GPlug.current_token(conn)
-    refute GPlug.current_claims(conn)
+    refute Guardian.Plug.current_token(conn)
+    refute Guardian.Plug.current_claims(conn)
 
-    assert GPlug.current_token(conn, key: :secret) == ctx.token
-    assert GPlug.current_claims(conn, key: :secret) == ctx.claims
+    assert Guardian.Plug.current_token(conn, key: :secret) == ctx.token
+    assert Guardian.Plug.current_claims(conn, key: :secret) == ctx.claims
   end
 
   test "with a token and mismatching claims", ctx do
@@ -135,8 +135,8 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       |> VerifyHeader.call(module: ctx.impl, error_handler: ctx.handler, claims: ctx.claims)
 
     refute conn.status == 401
-    assert GPlug.current_token(conn) == ctx.token
-    assert GPlug.current_claims(conn) == ctx.claims
+    assert Guardian.Plug.current_token(conn) == ctx.token
+    assert Guardian.Plug.current_claims(conn) == ctx.claims
   end
 
   test "with a token and no specified claims", ctx do
@@ -147,8 +147,8 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       |> VerifyHeader.call(module: ctx.impl, error_handler: ctx.handler)
 
     refute conn.status == 401
-    assert GPlug.current_token(conn) == ctx.token
-    assert GPlug.current_claims(conn) == ctx.claims
+    assert Guardian.Plug.current_token(conn) == ctx.token
+    assert Guardian.Plug.current_claims(conn) == ctx.claims
   end
 
   test "with an invalid token", ctx do

--- a/test/guardian/plug/verify_session_test.exs
+++ b/test/guardian/plug/verify_session_test.exs
@@ -3,8 +3,8 @@ defmodule Guardian.Plug.VerifySessionTest do
 
   import Plug.Test
 
-  alias Guardian.Plug, as: GPlug
-  alias GPlug.{VerifySession, Pipeline}
+  alias Guardian.Plug.Pipeline
+  alias Guardian.Plug.VerifySession
 
   use ExUnit.Case, async: true
 
@@ -46,8 +46,8 @@ defmodule Guardian.Plug.VerifySessionTest do
 
   test "with no session" do
     conn = :get |> conn("/") |> VerifySession.call([])
-    assert GPlug.current_token(conn, []) == nil
-    assert GPlug.current_claims(conn, []) == nil
+    assert Guardian.Plug.current_token(conn, []) == nil
+    assert Guardian.Plug.current_claims(conn, []) == nil
   end
 
   test "it uses the module from options", ctx do
@@ -57,8 +57,8 @@ defmodule Guardian.Plug.VerifySessionTest do
       |> init_test_session(%{guardian_default_token: ctx.token})
       |> VerifySession.call(module: ctx.impl)
 
-    assert GPlug.current_token(conn, []) == ctx.token
-    assert GPlug.current_claims(conn, []) == ctx.claims
+    assert Guardian.Plug.current_token(conn, []) == ctx.token
+    assert Guardian.Plug.current_claims(conn, []) == ctx.claims
   end
 
   test "it finds the module from the pipeline", ctx do
@@ -69,8 +69,8 @@ defmodule Guardian.Plug.VerifySessionTest do
       |> Pipeline.put_module(ctx.impl)
       |> VerifySession.call([])
 
-    assert GPlug.current_token(conn, []) == ctx.token
-    assert GPlug.current_claims(conn, []) == ctx.claims
+    assert Guardian.Plug.current_token(conn, []) == ctx.token
+    assert Guardian.Plug.current_claims(conn, []) == ctx.claims
   end
 
   test "with an existing token on the connection it leaves it intact", ctx do
@@ -80,12 +80,12 @@ defmodule Guardian.Plug.VerifySessionTest do
       :get
       |> conn("/")
       |> init_test_session(%{guardian_default_token: ctx.token})
-      |> GPlug.put_current_token(token)
-      |> GPlug.put_current_claims(claims)
+      |> Guardian.Plug.put_current_token(token)
+      |> Guardian.Plug.put_current_claims(claims)
       |> VerifySession.call([])
 
-    assert GPlug.current_token(conn) == token
-    assert GPlug.current_claims(conn) == claims
+    assert Guardian.Plug.current_token(conn) == token
+    assert Guardian.Plug.current_claims(conn) == claims
   end
 
   test "with no token in the session" do
@@ -95,8 +95,8 @@ defmodule Guardian.Plug.VerifySessionTest do
       |> init_test_session(%{some: "other value"})
       |> VerifySession.call([])
 
-    refute GPlug.current_token(conn)
-    refute GPlug.current_claims(conn)
+    refute Guardian.Plug.current_token(conn)
+    refute Guardian.Plug.current_claims(conn)
   end
 
   test "with no module", ctx do
@@ -115,11 +115,11 @@ defmodule Guardian.Plug.VerifySessionTest do
       |> init_test_session(%{guardian_secret_token: ctx.token})
       |> VerifySession.call(module: ctx.impl, key: :secret)
 
-    refute GPlug.current_token(conn)
-    refute GPlug.current_claims(conn)
+    refute Guardian.Plug.current_token(conn)
+    refute Guardian.Plug.current_claims(conn)
 
-    assert GPlug.current_token(conn, key: :secret) == ctx.token
-    assert GPlug.current_claims(conn, key: :secret) == ctx.claims
+    assert Guardian.Plug.current_token(conn, key: :secret) == ctx.token
+    assert Guardian.Plug.current_claims(conn, key: :secret) == ctx.claims
   end
 
   test "with a token and mismatching claims", ctx do
@@ -141,8 +141,8 @@ defmodule Guardian.Plug.VerifySessionTest do
       |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, claims: ctx.claims)
 
     refute conn.status == 401
-    assert GPlug.current_token(conn) == ctx.token
-    assert GPlug.current_claims(conn) == ctx.claims
+    assert Guardian.Plug.current_token(conn) == ctx.token
+    assert Guardian.Plug.current_claims(conn) == ctx.claims
   end
 
   test "with a token and no specified claims", ctx do
@@ -153,8 +153,8 @@ defmodule Guardian.Plug.VerifySessionTest do
       |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler)
 
     refute conn.status == 401
-    assert GPlug.current_token(conn) == ctx.token
-    assert GPlug.current_claims(conn) == ctx.claims
+    assert Guardian.Plug.current_token(conn) == ctx.token
+    assert Guardian.Plug.current_claims(conn) == ctx.claims
   end
 
   test "with an invalid token", ctx do
@@ -179,10 +179,10 @@ defmodule Guardian.Plug.VerifySessionTest do
 
     refute conn.status == 401
 
-    assert GPlug.current_token(conn) == ctx.token
-    assert GPlug.current_claims(conn) == ctx.claims
+    assert Guardian.Plug.current_token(conn) == ctx.token
+    assert Guardian.Plug.current_claims(conn) == ctx.claims
 
-    assert GPlug.current_token(conn, key: :admin) == token
-    assert GPlug.current_claims(conn, key: :admin) == claims
+    assert Guardian.Plug.current_token(conn, key: :admin) == token
+    assert Guardian.Plug.current_claims(conn, key: :admin) == claims
   end
 end

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -1,8 +1,6 @@
 defmodule Guardian.PlugTest do
   @moduledoc false
 
-  alias Guardian.Plug, as: GPlug
-
   import Guardian.Support.Utils, only: [gather_function_calls: 0]
   use Plug.Test
 
@@ -69,19 +67,19 @@ defmodule Guardian.PlugTest do
 
   describe "getters and setters" do
     test "put_current_token", ctx do
-      conn = GPlug.put_current_token(ctx.conn, "ToKen", [])
+      conn = Guardian.Plug.put_current_token(ctx.conn, "ToKen", [])
       assert conn.private[:guardian_default_token] == "ToKen"
 
-      conn = GPlug.put_current_token(ctx.conn, "tOkEn", key: :bob)
+      conn = Guardian.Plug.put_current_token(ctx.conn, "tOkEn", key: :bob)
       assert conn.private[:guardian_bob_token] == "tOkEn"
     end
 
     test "put_current_claims", ctx do
-      conn = GPlug.put_current_claims(ctx.conn, %{my: "claims"}, [])
+      conn = Guardian.Plug.put_current_claims(ctx.conn, %{my: "claims"}, [])
       assert conn.private[:guardian_default_claims] == %{my: "claims"}
 
       conn =
-        GPlug.put_current_claims(
+        Guardian.Plug.put_current_claims(
           ctx.conn,
           %{bob: "claims"},
           key: :bob
@@ -91,11 +89,11 @@ defmodule Guardian.PlugTest do
     end
 
     test "put_current_resource", ctx do
-      conn = GPlug.put_current_resource(ctx.conn, "resource", [])
+      conn = Guardian.Plug.put_current_resource(ctx.conn, "resource", [])
       assert conn.private[:guardian_default_resource] == "resource"
 
       conn =
-        GPlug.put_current_resource(
+        Guardian.Plug.put_current_resource(
           ctx.conn,
           "resource2",
           key: :bob
@@ -105,46 +103,46 @@ defmodule Guardian.PlugTest do
     end
 
     test "current_token", ctx do
-      assert GPlug.current_token(ctx.conn, []) == nil
+      assert Guardian.Plug.current_token(ctx.conn, []) == nil
 
       conn = Plug.Conn.put_private(ctx.conn, :guardian_default_token, "tOkEn")
-      assert GPlug.current_token(conn, []) == "tOkEn"
+      assert Guardian.Plug.current_token(conn, []) == "tOkEn"
 
       conn = Plug.Conn.put_private(ctx.conn, :guardian_bob_token, "token")
-      assert GPlug.current_token(conn, key: :bob) == "token"
+      assert Guardian.Plug.current_token(conn, key: :bob) == "token"
     end
 
     test "current_claims", ctx do
-      assert GPlug.current_claims(ctx.conn, []) == nil
+      assert Guardian.Plug.current_claims(ctx.conn, []) == nil
 
       conn = Plug.Conn.put_private(ctx.conn, :guardian_default_claims, %{a: "b"})
-      assert GPlug.current_claims(conn, []) == %{a: "b"}
+      assert Guardian.Plug.current_claims(conn, []) == %{a: "b"}
 
       conn = Plug.Conn.put_private(ctx.conn, :guardian_bob_token, %{c: "d"})
-      assert GPlug.current_token(conn, key: :bob) == %{c: "d"}
+      assert Guardian.Plug.current_token(conn, key: :bob) == %{c: "d"}
     end
 
     test "current_resource", ctx do
-      assert GPlug.current_resource(ctx.conn, []) == nil
+      assert Guardian.Plug.current_resource(ctx.conn, []) == nil
 
       conn = Plug.Conn.put_private(ctx.conn, :guardian_default_resource, :r1)
-      assert GPlug.current_resource(conn, []) == :r1
+      assert Guardian.Plug.current_resource(conn, []) == :r1
 
       conn = Plug.Conn.put_private(ctx.conn, :guardian_bob_resource, :r2)
-      assert GPlug.current_resource(conn, key: :bob) == :r2
+      assert Guardian.Plug.current_resource(conn, key: :bob) == :r2
     end
 
     test "authenticated? is true when there is a token present", ctx do
-      refute GPlug.authenticated?(ctx.conn, [])
-      refute GPlug.authenticated?(ctx.conn, key: :bob)
+      refute Guardian.Plug.authenticated?(ctx.conn, [])
+      refute Guardian.Plug.authenticated?(ctx.conn, key: :bob)
 
       conn =
         ctx.conn
         |> Plug.Conn.put_private(:guardian_default_token, "a")
         |> Plug.Conn.put_private(:guardian_bob_token, "b")
 
-      assert GPlug.authenticated?(conn, [])
-      assert GPlug.authenticated?(conn, key: :bob)
+      assert Guardian.Plug.authenticated?(conn, [])
+      assert Guardian.Plug.authenticated?(conn, key: :bob)
     end
   end
 
@@ -153,9 +151,9 @@ defmodule Guardian.PlugTest do
 
     test "it calls the right things", ctx do
       conn = ctx.conn
-      assert %Plug.Conn{} = xconn = GPlug.sign_in(conn, ctx.impl, @resource, %{}, [])
+      assert %Plug.Conn{} = xconn = Guardian.Plug.sign_in(conn, ctx.impl, @resource, %{}, [])
 
-      refute GPlug.session_active?(xconn)
+      refute Guardian.Plug.session_active?(xconn)
 
       token = xconn.private[:guardian_default_token]
       claims = xconn.private[:guardian_default_claims]
@@ -176,9 +174,11 @@ defmodule Guardian.PlugTest do
 
     test "it stores the information in the correct location", ctx do
       conn = ctx.conn
-      assert %Plug.Conn{} = xconn = GPlug.sign_in(conn, ctx.impl, @resource, %{}, key: :bob)
 
-      refute GPlug.session_active?(conn)
+      assert %Plug.Conn{} =
+               xconn = Guardian.Plug.sign_in(conn, ctx.impl, @resource, %{}, key: :bob)
+
+      refute Guardian.Plug.session_active?(conn)
 
       assert xconn.private[:guardian_bob_token]
       assert xconn.private[:guardian_bob_claims]
@@ -195,9 +195,9 @@ defmodule Guardian.PlugTest do
 
     test "it calls the right things", ctx do
       conn = ctx.conn
-      assert %Plug.Conn{} = xconn = GPlug.sign_in(conn, ctx.impl, @resource, %{}, [])
+      assert %Plug.Conn{} = xconn = Guardian.Plug.sign_in(conn, ctx.impl, @resource, %{}, [])
 
-      assert GPlug.session_active?(xconn)
+      assert Guardian.Plug.session_active?(xconn)
 
       token = xconn.private[:guardian_default_token]
       claims = xconn.private[:guardian_default_claims]
@@ -254,7 +254,7 @@ defmodule Guardian.PlugTest do
     test "it calls the right things", ctx do
       %{conn: conn, bob: %{token: bob_token, claims: bob_claims}} = ctx
 
-      assert %Plug.Conn{} = xconn = GPlug.sign_out(conn, ctx.impl, key: :bob)
+      assert %Plug.Conn{} = xconn = Guardian.Plug.sign_out(conn, ctx.impl, key: :bob)
 
       refute xconn.private[:guardian_bob_token]
       refute xconn.private[:guardian_bob_claims]
@@ -284,7 +284,7 @@ defmodule Guardian.PlugTest do
         jane: %{token: jane_token, claims: jane_claims}
       } = ctx
 
-      assert %Plug.Conn{} = xconn = GPlug.sign_out(conn, ctx.impl, [])
+      assert %Plug.Conn{} = xconn = Guardian.Plug.sign_out(conn, ctx.impl, [])
 
       refute xconn.private[:guardian_bob_token]
       refute xconn.private[:guardian_bob_claims]
@@ -343,7 +343,7 @@ defmodule Guardian.PlugTest do
     test "it calls the right things", ctx do
       %{conn: conn, bob: %{token: bob_token, claims: bob_claims}} = ctx
 
-      assert %Plug.Conn{} = xconn = GPlug.sign_out(conn, ctx.impl, key: :bob)
+      assert %Plug.Conn{} = xconn = Guardian.Plug.sign_out(conn, ctx.impl, key: :bob)
 
       refute xconn.private[:guardian_bob_token]
       refute xconn.private[:guardian_bob_claims]
@@ -370,7 +370,7 @@ defmodule Guardian.PlugTest do
         jane: %{token: jane_token, claims: jane_claims}
       } = ctx
 
-      assert %Plug.Conn{} = xconn = GPlug.sign_out(conn, ctx.impl, [])
+      assert %Plug.Conn{} = xconn = Guardian.Plug.sign_out(conn, ctx.impl, [])
 
       refute xconn.private[:guardian_bob_token]
       refute xconn.private[:guardian_bob_claims]
@@ -400,7 +400,7 @@ defmodule Guardian.PlugTest do
 
     test "it creates a cookie with the default token and key", ctx do
       conn = ctx.conn
-      assert %Plug.Conn{} = xconn = GPlug.remember_me(conn, ctx.impl, @resource, %{}, [])
+      assert %Plug.Conn{} = xconn = Guardian.Plug.remember_me(conn, ctx.impl, @resource, %{}, [])
 
       assert Map.has_key?(xconn.resp_cookies, "guardian_default_token")
       %{value: token, max_age: max_age} = Map.get(xconn.resp_cookies, "guardian_default_token")
@@ -427,7 +427,7 @@ defmodule Guardian.PlugTest do
       old_token = Poison.encode!(%{claims: claims}) |> Base.encode64()
 
       assert %Plug.Conn{} =
-               xconn = GPlug.remember_me_from_token(conn, ctx.impl, old_token, claims)
+               xconn = Guardian.Plug.remember_me_from_token(conn, ctx.impl, old_token, claims)
 
       assert Map.has_key?(xconn.resp_cookies, "guardian_default_token")
 
@@ -470,7 +470,7 @@ defmodule Guardian.PlugTest do
   end
 
   defmodule PipelineImpl do
-    use GPlug.Pipeline,
+    use Guardian.Plug.Pipeline,
       otp_app: :guardian,
       module: __MODULE__.Impl,
       error_handler: __MODULE__.Handler

--- a/test/guardian/token/jwt_test.exs
+++ b/test/guardian/token/jwt_test.exs
@@ -116,7 +116,8 @@ defmodule Guardian.Token.JwtTest do
 
   describe "create_token" do
     alias Guardian.Token.Jwt
-    alias JOSE.{JWK, JWT}
+    alias JOSE.JWK
+    alias JOSE.JWT
 
     test "create a token plain token", ctx do
       secret = :secret_key |> ctx.impl.config() |> JWK.from_oct()
@@ -427,7 +428,8 @@ defmodule Guardian.Token.JwtTest do
 
   describe "with secret fetcher" do
     alias Guardian.Token.Jwt
-    alias JOSE.{JWK, JWT}
+    alias JOSE.JWK
+    alias JOSE.JWT
 
     test "uses the custom secret fetcher", ctx do
       secret = "this_secret_yo"

--- a/test/support/token_module.ex
+++ b/test/support/token_module.ex
@@ -5,14 +5,14 @@ defmodule Guardian.Support.TokenModule do
   @behaviour Guardian.Token
 
   defmodule SecretFetcher do
-    alias Guardian.Token.Jwt.SecretFetcher.SecretFetcherDefaultImpl, as: DI
+    alias Guardian.Token.Jwt.SecretFetcher.SecretFetcherDefaultImpl
 
     def fetch_signing_secret(mod, opts) do
       if Keyword.has_key?(opts, :fetched_secret) do
         val = Keyword.get(opts, :fetched_secret)
         {:ok, val}
       else
-        DI.fetch_signing_secret(mod, opts)
+        SecretFetcherDefaultImpl.fetch_signing_secret(mod, opts)
       end
     end
 
@@ -22,7 +22,7 @@ defmodule Guardian.Support.TokenModule do
         send(self(), {:secret_fetcher, headers})
         {:ok, val}
       else
-        DI.fetch_verifying_secret(mod, headers, opts)
+        SecretFetcherDefaultImpl.fetch_verifying_secret(mod, headers, opts)
       end
     end
   end


### PR DESCRIPTION
Also removes the {}'d aliases and prefers separate aliases which can be alphabetized. 

If any of these are desired to be restored to their former glory, I can for sure do that on a case by case / class by class basis, or separate into separate PRs, but I think these are generally "good changes". 