### PR TITLE
Expose a function to set a token into the session

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -85,7 +85,7 @@ if Code.ensure_loaded?(Plug) do
           do: Guardian.Plug.remember_me(conn, implementation(), resource, claims, opts)
 
         def remember_me_from_token(conn, token, claims \\ %{}, opts \\ []),
-          do: Guardian.Plug.remember_me_from_token(conn, implementation(), token, claims, opts)
+          do: Guardian.Plug.remember_me_from_token(conn, token, claims, opts)
 
         def clear_remember_me(conn, opts \\ []),
           do: Guardian.Plug.clear_remember_me(conn, opts)
@@ -181,11 +181,10 @@ if Code.ensure_loaded?(Plug) do
 
     @spec put_session_token(
             Plug.Conn.t(),
-            module,
             Guardian.Token.token(),
             Guardian.options()
           ) :: Plug.Conn.t()
-    def put_session_token(conn, mod, token, opts \\ []) do
+    def put_session_token(conn, token, opts \\ []) do
       key =
         conn
         |> fetch_key(opts)
@@ -204,7 +203,7 @@ if Code.ensure_loaded?(Plug) do
            {:ok, conn} <-
              returning_tuple({impl, :after_sign_in, [conn, resource, token, full_claims, opts]}) do
         if session_active?(conn) do
-          put_session_token(conn, impl, token, opts)
+          put_session_token(conn, token, opts)
         else
           conn
         end

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -219,6 +219,20 @@ defmodule Guardian.PlugTest do
     end
   end
 
+  describe "put_session_token" do
+    @resource %{id: "bob"}
+
+    setup %{conn: conn} do
+      {:ok, %{conn: init_test_session(conn, %{})}}
+    end
+
+    test "it puts the new token in the session", ctx do
+      conn = ctx.conn
+      new_conn = Guardian.Plug.put_session_token(conn, ctx.impl, "hai bob")
+      assert get_session(new_conn, :guardian_default_token) == "hai bob"
+    end
+  end
+
   describe "sign_out with session" do
     @bob %{id: "bobby"}
     @jane %{id: "jane"}

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -228,7 +228,7 @@ defmodule Guardian.PlugTest do
 
     test "it puts the new token in the session", ctx do
       conn = ctx.conn
-      new_conn = Guardian.Plug.put_session_token(conn, ctx.impl, "hai bob")
+      new_conn = Guardian.Plug.put_session_token(conn, "hai bob")
       assert get_session(new_conn, :guardian_default_token) == "hai bob"
     end
   end


### PR DESCRIPTION
When you refresh a token, you can't put it into the session (when using sessions). 

Adds a function to allow adding a token to the session in the right place. 