### PR TITLE
Elixir 1.8 prep

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -504,7 +504,7 @@ defmodule Guardian do
   Provides the current system time in seconds
   """
   @spec timestamp() :: pos_integer
-  def timestamp, do: System.system_time(:seconds)
+  def timestamp, do: System.system_time(:second)
 
   @doc """
   Converts keys in a map or list of maps to strings

--- a/lib/guardian/permissions/bitwise.ex
+++ b/lib/guardian/permissions/bitwise.ex
@@ -106,7 +106,7 @@ defmodule Guardian.Permissions.Bitwise do
   @type permission_set :: %{optional(label) => pos_integer}
   @type t :: %{optional(label) => permission_set}
 
-  @type input_label :: String.t() :: atom
+  @type input_label :: String.t() | atom
   @type input_set :: [input_label, ...] | pos_integer
   @type input_permissions :: %{optional(input_label) => input_set}
 

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -93,7 +93,7 @@ if Code.ensure_loaded?(Plug) do
     end
 
     def session_active?(conn) do
-      key = :seconds |> System.os_time() |> to_string()
+      key = :second |> System.os_time() |> to_string()
       get_session(conn, key) == nil
     rescue
       ArgumentError -> false


### PR DESCRIPTION
Hi and thanks for the library! I was trying out 1.8-rc0 with one of my applications which depends on Guardian and got some new compiler warnings:
```
warning: deprecated time unit: :seconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
  (guardian) lib/guardian/token/jwt.ex:406: Guardian.Token.Jwt.set_iat/1
  (guardian) lib/guardian/token/jwt.ex:276: Guardian.Token.Jwt.build_claims/5
  (guardian) lib/guardian.ex:756: Guardian.returning_tuple/1
  (guardian) lib/guardian.ex:580: Guardian.encode_and_sign/4
```
While fixing that warning I also noticed: 
```
warning: invalid type annotation. When using the | operator to represent the union of types, make sure to wrap type annotations in parentheses: String.t() :: atom
  lib/guardian/permissions/bitwise.ex:109
```
This PR fixes these warnings.
