### PR TITLE
Fixes Dialyzer errors for matching on opaque type.

### DIFF
--- a/lib/guardian/permissions/bitwise.ex
+++ b/lib/guardian/permissions/bitwise.ex
@@ -221,9 +221,9 @@ defmodule Guardian.Permissions.Bitwise do
         end)
       end
 
-      defp do_any_permissions?(nil, %MapSet{}), do: false
+      defp do_any_permissions?(nil, _), do: false
 
-      defp do_any_permissions?(list, %MapSet{} = needs) do
+      defp do_any_permissions?(list, needs) do
         matches = needs |> MapSet.intersection(MapSet.new(list))
         MapSet.size(matches) > 0
       end


### PR DESCRIPTION
Only called internally as private function, from an explicit `MapSet.new(...)` call so it was unnecessary to match. This also fixes a no_return warning from the macro expansion.