### PR TITLE
Override cookie defaults in remember_me with values from module config

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -291,7 +291,7 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp cookie_options(mod, _claims) do
-      mod.config(:cookie_options, []) ++ @default_cookie_options
+      Keyword.merge(@default_cookie_options, mod.config(:cookie_options, []))
     end
 
     defp add_data_to_conn(conn, resource, token, claims, opts) do


### PR DESCRIPTION
We found that when we attempt to set the `max_age` in our Guardian module's config, this value would not override the default `cookie_options` in `Guardian.Plug.remember_me`. This is because the options list is concatenated (defaults last) and eventually Phoenix uses `:maps.from_list/1` which prefers the right most value. This PR should fix the issue. 

Example config:
```
config :my_app, MyApp.Guardian,
  issuer: "MyApp",
  secret_key: "...",
  permissions: %{
    default: [:read_users, :write_users]
  },
  cookie_options: [max_age: 100]
```