### PR TITLE
Fix dialyzer warning in Guardian.Plug

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -54,7 +54,7 @@ if Code.ensure_loaded?(Plug) do
 
     defmacro __using__(impl) do
       quote do
-        @spec implementation() :: module
+        @spec implementation() :: unquote(impl)
         def implementation, do: unquote(impl)
 
         def put_current_token(conn, token, opts \\ []),


### PR DESCRIPTION
Hey,

I noticed that dialyzer complains about supertype of success specification of generated `implementation/0` function in generated `(...).Plug` module:

```
Type specification 'Elixir.MyApp.Guardian.Plug':implementation() -> module() is a supertype of the success typing: 'Elixir.MyApp.Guardian.Plug':implementation() -> 'Elixir.MyApp.Guardian'
```

There is only 1 known value returned from that function, so we can also put it in function specification.