### PR TITLE
Fixes Dialyzer error for Guardian.Plug.Pipeline.implementation/0

### DIFF
--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -54,7 +54,7 @@ if Code.ensure_loaded?(Plug) do
 
     defmacro __using__(impl) do
       quote do
-        @spec implementation() :: module
+        @spec implementation() :: unquote(impl)
         def implementation, do: unquote(impl)
 
         def put_current_token(conn, token, opts \\ []),


### PR DESCRIPTION
Addresses issue whereby dialyzer will warn that  "Type specification
is a supertype of the success typing." on the generated
`implementation/0` function when using `Guardian.Plug.Pipeline`.

This is technically an "underspecification" error.
See: http://erlang.org/doc/man/dialyzer.html `-Wunderspecs`

Full Dialyzer Warning:
```
lib/my_app/authorisation/guardian.ex:2:contract_supertype
Type specification is a supertype of the success typing.

Function:
MyApp.Authorisation.Guardian.Plug.implementation/0

Type specification:
@spec implementation() :: module()

Success typing:
@spec implementation() :: MyApp.Authorisation.Guardian
```

Usage:
```
defmodule MyApp.Authorisation.Pipeline do
  use Guardian.Plug.Pipeline,
    otp_app: :my_app,
    error_handler: MyApp.Authorisation.ErrorHandler,
    module: MyApp.Authorisation.Guardian  # <- where implementation is passed, that is supertype of `module()`

  plug Guardian.Plug.VerifyHeader, realm: "Bearer"
  plug Guardian.Plug.EnsureAuthenticated
  plug Guardian.Plug.LoadResource
end
```

I feel this is a minor issue, but given the fact this code is generated for the specific "module" the direct use of the unquoted module name (in this case ` MyApp.Authorisation.Guardian`) should be fine.