### PR TITLE
Fix docs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
 elixir:
   - 1.8
   - 1.7
-  - 1.6
 
 otp_release:
   - 21.1
@@ -16,8 +15,6 @@ otp_release:
 
 matrix:
   exclude:
-    - elixir: 1.6
-      otp_release: 18.3
     - elixir: 1.8
       otp_release: 19.3
     - elixir: 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ matrix:
       otp_release: 19.3
     - elixir: 1.8
       otp_release: 18.3
+    - elixir: 1.7
+      otp_release: 18.3
+
+before_script:
+  - travis_wait mix dialyzer --plt
 
 script:
   - make testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,12 @@ matrix:
 script:
   - make testing
 
+before_cache:
+  - rf -rf _build/$MIX_HOME/lib
+
 cache:
   directories:
-    - _build
-    - deps
-    - priv/plts
+    - _build/$MIX_HOME
 
 after_script:
   - make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ sudo: false
 notifications:
   email: false
 
+before_cache:
+  - rm -rf _build/$MIX_HOME/lib
+
+cache:
+  directories:
+    - _build/$MIX_HOME
+
 elixir:
   - 1.8
   - 1.7
@@ -23,14 +30,8 @@ matrix:
 script:
   - make testing
 
-before_cache:
-  - rf -rf _build/$MIX_HOME/lib
-
-cache:
-  directories:
-    - _build/$MIX_HOME
-
 after_script:
   - make docs
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,24 @@ notifications:
   email: false
 
 elixir:
+  - 1.8
+  - 1.7
   - 1.6
 
 otp_release:
+  - 21.1
   - 20.3
-  - 21.0
+  - 19.3
+  - 18.3
+
+matrix:
+  exclude:
+    - elixir: 1.6
+      otp_release: 18.3
+    - elixir: 1.8
+      otp_release: 19.3
+    - elixir: 1.8
+      otp_release: 18.3
 
 script:
   - make testing

--- a/mix.exs
+++ b/mix.exs
@@ -27,12 +27,7 @@ defmodule Guardian.Mixfile do
       docs: docs(),
       deps: deps(),
       xref: [exclude: [:phoenix]],
-      dialyzer: [
-        plt_add_deps: :transitive,
-        plt_add_apps: [:mix],
-        plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
-        flags: [:race_conditions, :no_opaque]
-      ],
+      dialyzer: dialyxir(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
         coveralls: :test,
@@ -58,6 +53,14 @@ defmodule Guardian.Mixfile do
       groups_for_modules: groups_for_modules(),
       extras: extras(),
       groups_for_extras: groups_for_extras()
+    ]
+  end
+
+  defp dialyxir do
+    [
+      plt_add_deps: :transitive,
+      plt_add_apps: [:mix],
+      flags: [:race_conditions, :no_opaque]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -168,7 +168,7 @@ defmodule Guardian.Mixfile do
       # Tools
       {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:dialyxir, ">= 1.0.0-rc4", only: [:dev], runtime: false},
-      {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
+      {:ex_doc, ">= 0.19.1", only: [:dev], runtime: false},
       {:excoveralls, ">= 0.0.0", only: [:test], runtime: false},
       {:inch_ex, ">= 0.0.0", only: [:dev], runtime: false},
       {:jason, "~> 1.1", only: [:dev, :test], runtume: false}


### PR DESCRIPTION
Currently `mix docs` fails with the following error 
`
** (InchEx.Docs.Retriever.Error) module Guardian.Config was not compiled with flag --docs
    lib/inch_ex/docs/retriever.ex:83: InchEx.Docs.Retriever.verify_module/1
    lib/inch_ex/docs/retriever.ex:72: InchEx.Docs.Retriever.get_module/2
    (elixir) lib/enum.ex:1314: Enum."-map/2-lists^map/1-0-"/2
    lib/inch_ex/docs/retriever.ex:51: InchEx.Docs.Retriever.docs_from_modules/2
    lib/inch_ex.ex:39: InchEx.generate_docs/4
    lib/mix/tasks/inch.ex:48: Mix.Tasks.Inch.run/4
    (mix) lib/mix/task.ex:316: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
`

Updating ex_docs fixes this.
