### PR TITLE
update ex_doc to be able to generate docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -165,7 +165,7 @@ defmodule Guardian.Mixfile do
       # Tools
       {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:dialyxir, ">= 1.0.0-rc4", only: [:dev], runtime: false},
-      {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
+      {:ex_doc, ">= 0.19.1", only: [:dev], runtime: false},
       {:excoveralls, ">= 0.0.0", only: [:test], runtime: false},
       {:inch_ex, ">= 0.0.0", only: [:dev], runtime: false},
       {:jason, "~> 1.1", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
Currently `mix docs` fails with the following error
`** (InchEx.Docs.Retriever.Error) module Guardian.Config was not compiled with flag --docs lib/inch_ex/docs/retriever.ex:83: InchEx.Docs.Retriever.verify_module/1 lib/inch_ex/docs/retriever.ex:72: InchEx.Docs.Retriever.get_module/2 (elixir) lib/enum.ex:1314: Enum."-map/2-lists^map/1-0-"/2 lib/inch_ex/docs/retriever.ex:51: InchEx.Docs.Retriever.docs_from_modules/2 lib/inch_ex.ex:39: InchEx.generate_docs/4 lib/mix/tasks/inch.ex:48: Mix.Tasks.Inch.run/4 (mix) lib/mix/task.ex:316: Mix.Task.run_task/3 (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2`

Updating ex_docs fixes this.