### PR TITLE
Fix error messages

### DIFF
--- a/lib/guardian/permissions/bitwise.ex
+++ b/lib/guardian/permissions/bitwise.ex
@@ -435,7 +435,7 @@ defmodule Guardian.Permissions.Bitwise do
 
       defp do_call(conn, %{claims: nil} = ctx, opts) do
         ctx.handler
-        |> apply(:auth_error, [conn, {:unauthorized, :missing_claims}, opts])
+        |> apply(:auth_error, [conn, {:unauthorized, "Missing claims"}, opts])
         |> halt()
       end
 
@@ -448,7 +448,7 @@ defmodule Guardian.Permissions.Bitwise do
           conn
         else
           ctx.handler
-          |> apply(:auth_error, [conn, {:unauthorized, :insufficient_permission}, opts])
+          |> apply(:auth_error, [conn, {:unauthorized, "Insufficient permission"}, opts])
           |> halt()
         end
       end
@@ -466,7 +466,7 @@ defmodule Guardian.Permissions.Bitwise do
           conn
         else
           ctx.handler
-          |> apply(:auth_error, [conn, {:unauthorized, :insufficient_permission}, opts])
+          |> apply(:auth_error, [conn, {:unauthorized, "Insufficient permission"}, opts])
           |> halt()
         end
       end

--- a/lib/guardian/permissions/bitwise.ex
+++ b/lib/guardian/permissions/bitwise.ex
@@ -435,7 +435,7 @@ defmodule Guardian.Permissions.Bitwise do
 
       defp do_call(conn, %{claims: nil} = ctx, opts) do
         ctx.handler
-        |> apply(:auth_error, [conn, {:unauthorized, :unauthorized}, opts])
+        |> apply(:auth_error, [conn, {:unauthorized, :missing_claims}, opts])
         |> halt()
       end
 
@@ -448,7 +448,7 @@ defmodule Guardian.Permissions.Bitwise do
           conn
         else
           ctx.handler
-          |> apply(:auth_error, [conn, {:unauthorized, :unauthorized}, opts])
+          |> apply(:auth_error, [conn, {:unauthorized, :insufficient_permission}, opts])
           |> halt()
         end
       end
@@ -466,7 +466,7 @@ defmodule Guardian.Permissions.Bitwise do
           conn
         else
           ctx.handler
-          |> apply(:auth_error, [conn, {:unauthorized, :unauthorized}, opts])
+          |> apply(:auth_error, [conn, {:unauthorized, :insufficient_permission}, opts])
           |> halt()
         end
       end

--- a/test/guardian/permissions/bitwise_test.exs
+++ b/test/guardian/permissions/bitwise_test.exs
@@ -292,7 +292,7 @@ defmodule Guardian.Permissions.BitwiseTest do
 
       assert conn.halted
       assert {403, _headers, body} = sent_resp(conn)
-      assert body == "{:unauthorized, :unauthorized}"
+      assert body == "{:unauthorized, :missing_claims}"
     end
 
     test "when looking in a different location with correct permissions", ctx do

--- a/test/guardian/permissions/bitwise_test.exs
+++ b/test/guardian/permissions/bitwise_test.exs
@@ -224,7 +224,7 @@ defmodule Guardian.Permissions.BitwiseTest do
       conn = Guardian.Permissions.Bitwise.call(ctx.conn, opts)
 
       assert {403, _headers, body} = sent_resp(conn)
-      assert body == "{:unauthorized, :unauthorized}"
+      assert body == "{:unauthorized, \"Insufficient permission\"}"
       assert conn.halted
     end
 
@@ -240,7 +240,7 @@ defmodule Guardian.Permissions.BitwiseTest do
       conn = Guardian.Permissions.Bitwise.call(ctx.conn, opts)
 
       assert {403, _headers, body} = sent_resp(conn)
-      assert body == "{:unauthorized, :unauthorized}"
+      assert body == "{:unauthorized, \"Insufficient permission\"}"
       assert conn.halted
     end
 
@@ -292,7 +292,7 @@ defmodule Guardian.Permissions.BitwiseTest do
 
       assert conn.halted
       assert {403, _headers, body} = sent_resp(conn)
-      assert body == "{:unauthorized, :missing_claims}"
+      assert body == "{:unauthorized, \"Missing claims\"}"
     end
 
     test "when looking in a different location with correct permissions", ctx do
@@ -330,7 +330,7 @@ defmodule Guardian.Permissions.BitwiseTest do
 
       assert conn.halted
       assert {403, _headers, body} = sent_resp(conn)
-      assert body == "{:unauthorized, :unauthorized}"
+      assert body == "{:unauthorized, \"Insufficient permission\"}"
     end
 
     test "when looking in a different location with incorrect one_of permissions", ctx do
@@ -339,7 +339,7 @@ defmodule Guardian.Permissions.BitwiseTest do
 
       assert conn.halted
       assert {403, _headers, body} = sent_resp(conn)
-      assert body == "{:unauthorized, :unauthorized}"
+      assert body == "{:unauthorized, \"Insufficient permission\"}"
     end
 
     test "with no permissions specified", ctx do


### PR DESCRIPTION
Related to #578

@ueberauth/developers I need your feedback on this, we currently send an error tuple to the clients with a text body containing that error tuple.

Should I send a human-readable message in this case?

I can fix this but I need your direction on what the proper fix for this is.