### PR TITLE
tidies up token documentation

### DIFF
--- a/guides/tokens/jwt/start.md
+++ b/guides/tokens/jwt/start.md
@@ -1,3 +1,21 @@
 # JWT Tokens
 
-The default implementation of a Token in Guardian is JWT.
+The default implementation of a Token in Guardian is [JWT](https://en.wikipedia.org/wiki/JSON_Web_Token).
+
+The default payload of a JWT token produced by Guardian contains the following:
+
+- `iss` (Issuer): Identifies principal that issued the JWT. This normally comes from your application config, e.g. `config :idp, Idp.Auth.Guardian, issuer: "idp"`.
+- `sub` (Subject): Identifies the subject. Identifies the subject of the JWT, e.g. `User:123`.
+- `aud` (Audience): Identifies the recipients that the JWT is intended for. By default it is the same as `iss`.
+- `exp` (Expiration Time): Identifies the expiration time on and after which the token will become invalid. It is represented as a unix timestamp.
+  The expiration time is set via the option `exp`. By default it's 4 weeks in Guardian.
+- `iat` (Issued at): Identifies the time at which the JWT was issued. It is represented as a unix timestamp.
+- `nbf` (Not before): Identifies the time at which the JWT will start to be accepted for processing. It is represented as a unix timestamp.
+  By default it is set to be 1 ms before `iat`.
+- `typ` (Token Type): The type of the token. By default it is `"access"`.
+  Note that this is not the same as the `typ` entry in the JWT's **header**, which will always be `"JWT"`.
+- `jti` (JWT ID): The unique id of the token.
+
+You can add custom claims additionally when calling the function `Guardian.encode_and_sign`.
+
+For further information, refer to the module [Guardian.Token.Jwt](https://hexdocs.pm/guardian/Guardian.Token.Jwt.html).

--- a/guides/tokens/start-tokens.md
+++ b/guides/tokens/start-tokens.md
@@ -4,16 +4,16 @@ Guardian uses the concept of a _token_ as a currency of authentication credentia
 
 Tokens can be anything that has the following properties:
 
-* tamper proof (signed/encrypted verifyable by the application)
+* tamper proof (signed/encrypted verifiable by the application)
 * include a payload (claims)
 
 Claims should be a map using string keys.
 
-JWT tokens (the default) fit these requirements and are widely supported in most languages using either hashed or cert based signing algorithms. However this is only one option. You can provide other behaviours like revocation, db tracking or another standard token type.
+[JWT tokens](https://en.wikipedia.org/wiki/JSON_Web_Token) (the default) fit these requirements and are widely supported in most languages using either hashed or cert based signing algorithms. However this is only one option. You can provide other behaviours like revocation, db tracking or another standard token type.
 
 Tokens can be provided by any means, they can be put into HTTP request headers, cookies, sessions; really as long as you can get your token to your application you can verify it and use it.
 
-Configuration of your token has two parts:
+Configuration of your token comes from two places:
 
-1. Config - options are provided by the token module that you're using
-2. Implementation module - The module for
+1. token module - the token module that you're using provides some default options
+2. Implementation module - you can provide custom options in your implementation module (the module that implements `Guardian` for your application).

--- a/lib/guardian/token/jwt.ex
+++ b/lib/guardian/token/jwt.ex
@@ -24,6 +24,7 @@ defmodule Guardian.Token.Jwt do
   * `allowed_algos` - The allowed algos to use for encoding and decoding.
                       See JOSE for available. Default ["HS512"]
   * `ttl` - The default time to live for all tokens. See the type in Guardian.ttl
+            The default by `Guardian.Token.JWT` is `{4, :weeks}`
   * `token_ttl` a map of `token_type` to `ttl`. Set specific ttls for specific types of tokens
   * `allowed_drift` The drift that is allowed when decoding/verifying a token in milli seconds
   * `verify_issuer` Verify that the token was issued by the configured issuer. Default false
@@ -37,6 +38,7 @@ defmodule Guardian.Token.Jwt do
   * `headers` The Jose headers that should be used
   * `allowed_algos`
   * `token_type` - Override the default token type
+                   The default is "access"
   * `ttl` - The time to live. See `Guardian.Token.ttl` type
 
   #### Example
@@ -111,6 +113,7 @@ defmodule Guardian.Token.Jwt do
                   token_verify_module: MyVerifyModule
     # ... snip
   end
+  ```
 
   ### SecretFetcher
 
@@ -119,7 +122,7 @@ defmodule Guardian.Token.Jwt do
   This will allow you to use the header values to determine dynamically the
   key that should be used.
 
-  ```
+  ```elixir
   defmodule MyCustomSecretFetcher do
     use Guardian.Token.Jwt.SecretFetcher
 


### PR DESCRIPTION
When using Guardian I found the documentation on tokens themselves to be relatively confusing. On many occasions I had to dig into Guardian source code to find the answers. I want to make it clearer.

- Expands JWT documentation
- Explains some default values used by `Guardian.Token.Jwt` in the moduledoc
- Fixes an error in moduledoc in `jwt.ex` which resulted in documentation not being rendered correctly
- Fixes some typos and errors