### PR TITLE
Cosmetic change for `Guardian.Plug.VerifyHeader` moduledoc

### DIFF
--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -6,8 +6,8 @@ if Code.ensure_loaded?(Plug) do
 
     In the case where:
 
-    a. The session is not loaded
-    b. A token is already found for `:key`
+    1. The session is not loaded
+    2. A token is already found for `:key`
 
     This plug will not do anything.
 
@@ -30,7 +30,7 @@ if Code.ensure_loaded?(Plug) do
     Options:
 
     * `claims` - The literal claims to check to ensure that a token is valid
-    * `header_name` - The name of the header to search for a token. Defaults to `authorization`. 
+    * `header_name` - The name of the header to search for a token. Defaults to `authorization`.
     * `realm` - The prefix for the token in the header. Defaults to `Bearer`. `:none` will not use a prefix.
     * `key` - The location to store the information in the connection. Defaults to: `default`
 


### PR DESCRIPTION
`a.` and `b.` doesn't show as a list in ExDoc.

| before | after |
| ---- | ---- |
| <img width="553" alt="スクリーンショット 2019-09-09 22 36 41" src="https://user-images.githubusercontent.com/10890/64537012-0ae56f00-d355-11e9-92d2-be11a932d404.png"> | <img width="547" alt="スクリーンショット 2019-09-09 22 38 25" src="https://user-images.githubusercontent.com/10890/64537029-1042b980-d355-11e9-98c7-e6ae448cf3b7.png"> |
