### PR TITLE
feat: configure conn halt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.1.0 (unreleased)
+
+### Enhancement
+
+* Add option `halt` to all plugs. This allows to optionally not halt the connection on error so downstream plugs are
+  still called [#617](https://github.com/ueberauth/guardian/pull/617)
+
 ## v2.0.0
 
 ### Enhancement

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -288,6 +288,15 @@ if Code.ensure_loaded?(Plug) do
       end
     end
 
+    @spec maybe_halt(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
+    def maybe_halt(conn, opts) do
+      if Keyword.get(opts, :halt, true) do
+        Plug.Conn.halt(conn)
+      else
+        conn
+      end
+    end
+
     defp fetch_token_key(conn, opts) do
       conn
       |> Pipeline.fetch_key(opts)

--- a/lib/guardian/plug/ensure_authenticated.ex
+++ b/lib/guardian/plug/ensure_authenticated.ex
@@ -18,6 +18,7 @@ if Code.ensure_loaded?(Plug) do
 
     * `claims` - The literal claims to check to ensure that a token is valid
     * `key` - The location to find the information in the connection. Defaults to: `default`
+    * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
 
     ## Example
 
@@ -63,7 +64,7 @@ if Code.ensure_loaded?(Plug) do
       conn
       |> Guardian.Plug.Pipeline.fetch_error_handler!(opts)
       |> apply(:auth_error, [conn, {:unauthenticated, reason}, opts])
-      |> Plug.Conn.halt()
+      |> Guardian.Plug.maybe_halt(opts)
     end
 
     @spec verify_claims(Guardian.Token.claims(), Keyword.t()) :: {:ok, Guardian.Token.claims()} | {:error, any}

--- a/lib/guardian/plug/ensure_not_authenticated.ex
+++ b/lib/guardian/plug/ensure_not_authenticated.ex
@@ -17,6 +17,7 @@ if Code.ensure_loaded?(Plug) do
     Options:
 
     * `key` - The location to find the information in the connection. Defaults to: `default`
+    * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
 
     ## Example
 
@@ -43,7 +44,7 @@ if Code.ensure_loaded?(Plug) do
         conn
         |> Guardian.Plug.Pipeline.fetch_error_handler!(opts)
         |> apply(:auth_error, [conn, {:already_authenticated, :already_authenticated}, opts])
-        |> Plug.Conn.halt()
+        |> Guardian.Plug.maybe_halt(opts)
       else
         conn
       end

--- a/lib/guardian/plug/load_resource.ex
+++ b/lib/guardian/plug/load_resource.ex
@@ -23,6 +23,7 @@ if Code.ensure_loaded?(Plug) do
 
     * `allow_blank` - boolean. If set to true, will try to load a resource but will not fail if no resource is found.
     * `key` - The location to find the information in the connection. Defaults to: `default`
+    * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
 
     ## Example
 
@@ -33,8 +34,6 @@ if Code.ensure_loaded?(Plug) do
       plug Guardian.Plug.LoadResource, key: :secret
       ```
     """
-
-    import Plug.Conn
 
     alias Guardian.Plug.Pipeline
 
@@ -76,7 +75,7 @@ if Code.ensure_loaded?(Plug) do
     defp return_error(conn, reason, opts) do
       handler = Pipeline.fetch_error_handler!(conn, opts)
       conn = apply(handler, :auth_error, [conn, {:no_resource_found, reason}, opts])
-      halt(conn)
+      Guardian.Plug.maybe_halt(conn, opts)
     end
   end
 end

--- a/lib/guardian/plug/verify_cookie.ex
+++ b/lib/guardian/plug/verify_cookie.ex
@@ -38,6 +38,7 @@ if Code.ensure_loaded?(Plug) do
     * `:exchange_from` - The type of the cookie (default `"refresh"`)
     * `:exchange_to` - The type of token to provide. Defaults to the implementation modules `default_type`
     * `:ttl` - The time to live of the exchanged token. Defaults to configured values.
+    * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
     """
 
     import Plug.Conn
@@ -85,7 +86,7 @@ if Code.ensure_loaded?(Plug) do
           conn
           |> Pipeline.fetch_error_handler!(opts)
           |> apply(:auth_error, [conn, {:invalid_token, reason}, opts])
-          |> halt()
+          |> Guardian.Plug.maybe_halt(opts)
 
         _ ->
           conn

--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -33,6 +33,7 @@ if Code.ensure_loaded?(Plug) do
     * `header_name` - The name of the header to search for a token. Defaults to `authorization`.
     * `realm` - The prefix for the token in the header. Defaults to `Bearer`. `:none` will not use a prefix.
     * `key` - The location to store the information in the connection. Defaults to: `default`
+    * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
 
     ### Example
 
@@ -100,7 +101,7 @@ if Code.ensure_loaded?(Plug) do
           conn
           |> Pipeline.fetch_error_handler!(opts)
           |> apply(:auth_error, [conn, {:invalid_token, reason}, opts])
-          |> halt()
+          |> Guardian.Plug.maybe_halt(opts)
 
         _ ->
           conn

--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -66,7 +66,7 @@ if Code.ensure_loaded?(Plug) do
           conn
           |> Pipeline.fetch_error_handler!(opts)
           |> apply(:auth_error, [conn, {:invalid_token, reason}, opts])
-          |> halt()
+          |> Guardian.Plug.maybe_halt(opts)
 
         _ ->
           conn

--- a/test/guardian/plug/ensure_authenticated_test.exs
+++ b/test/guardian/plug/ensure_authenticated_test.exs
@@ -47,6 +47,12 @@ defmodule Guardian.Plug.EnsureAuthenticatedTest do
       assert {401, _, "{:unauthenticated, :unauthenticated}"} = sent_resp(conn)
       assert conn.halted
     end
+
+    test "does not halt conn when option is set to false", ctx do
+      conn = EnsureAuthenticated.call(ctx.conn, module: ctx.impl, error_handler: ctx.handler, halt: false)
+      assert {401, _, "{:unauthenticated, :unauthenticated}"} = sent_resp(conn)
+      refute conn.halted
+    end
   end
 
   describe "with an authenticated token" do

--- a/test/guardian/plug/ensure_not_authenticated_test.exs
+++ b/test/guardian/plug/ensure_not_authenticated_test.exs
@@ -57,6 +57,12 @@ defmodule Guardian.Plug.EnsureNotAuthenticatedTest do
       assert {401, _, "{:already_authenticated, :already_authenticated}"} = sent_resp(conn)
       assert conn.halted
     end
+
+    test "does not halt conn when option is set to false", ctx do
+      conn = EnsureNotAuthenticated.call(ctx.conn, error_handler: ctx.handler, halt: false)
+      assert {401, _, "{:already_authenticated, :already_authenticated}"} = sent_resp(conn)
+      refute conn.halted
+    end
   end
 
   describe "with no verified token" do

--- a/test/guardian/plug/load_resource_test.exs
+++ b/test/guardian/plug/load_resource_test.exs
@@ -80,6 +80,12 @@ defmodule Guardian.Plug.LoadResourceTest do
       assert {401, _, "{:no_resource_found, :not_found}"} = sent_resp(conn)
       assert conn.halted
     end
+
+    test "does not halt conn when option is set to false", ctx do
+      conn = LoadResource.call(ctx.conn, module: ctx.impl, error_handler: ctx.handler, halt: false)
+      assert {401, _, "{:no_resource_found, :not_found}"} = sent_resp(conn)
+      refute conn.halted
+    end
   end
 
   describe "with a token and found resource" do

--- a/test/guardian/plug/verify_cookie_test.exs
+++ b/test/guardian/plug/verify_cookie_test.exs
@@ -96,6 +96,12 @@ defmodule Guardian.Plug.VerifyCookieTest do
       assert {401, _, "{:invalid_token, :invalid_token_type}"} = sent_resp(conn)
     end
 
+    test "does not halt conn when option is set to false", ctx do
+      conn = VerifyCookie.call(ctx.conn, exchange_from: "access", halt: false)
+      refute conn.halted
+      assert {401, _, "{:invalid_token, :invalid_token_type}"} = sent_resp(conn)
+    end
+
     test "with no existing token found", ctx do
       conn = VerifyCookie.call(ctx.conn, [])
 

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -159,5 +159,17 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       |> VerifyHeader.call(module: ctx.impl, error_handler: ctx.handler)
 
     assert conn.status == 401
+    assert conn.halted
+  end
+
+  test "does not halt conn when option is set to false", ctx do
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("authorization", "not a good one")
+      |> VerifyHeader.call(module: ctx.impl, error_handler: ctx.handler, halt: false)
+
+    assert conn.status == 401
+    refute conn.halted
   end
 end

--- a/test/guardian/plug/verify_session_test.exs
+++ b/test/guardian/plug/verify_session_test.exs
@@ -165,6 +165,18 @@ defmodule Guardian.Plug.VerifySessionTest do
       |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler)
 
     assert conn.status == 401
+    assert conn.halted
+  end
+
+  test "does not halt conn when option is set to false", ctx do
+    conn =
+      :get
+      |> conn("/")
+      |> init_test_session(%{guardian_default_token: "not a good one"})
+      |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, halt: false)
+
+    assert conn.status == 401
+    refute conn.halted
   end
 
   test "with multiple calls to different locations", ctx do


### PR DESCRIPTION
Hi! 

I finally got around to putting this PR together. It addresses the discussion in #401. 
The `halt` option is added to all relevant plugs and defaults to true, as to not break any current behaviour. Let me know what you think.

Cheers!