### PR TITLE
Version change to 2.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ mix.exs
 
 ```elixir
 defp deps do
-  [{:guardian, "~> 1.2"}]
+  [{:guardian, "~> 2.0"}]
 end
 ```
 


### PR DESCRIPTION
I am little confused but looks like a typo.

In mix.exs, the version is `@version "2.0.0"` so should we not use `~> 2.0` in *Installation* section now.

Installation section has `~> 1.2`

```
# mix.exs

defp deps do
  [{:guardian, "~> 1.2"}]
end
```

Please ignore if I missed some hidden context here