### PR TITLE
add auth_time and max_age features

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Creating with custom claims and options
 # Customize the secret
 {:ok, token, claims} = MyApp.Guardian.encode_and_sign(resource, %{}, secret: "custom")
 {:ok, token, claims} = MyApp.Guardian.encode_and_sign(resource, %{}, secret: {SomeMod, :some_func, ["some", "args"]})
+
+# Require an "auth_time" claim to be added.
+{:ok, token, claims} = MyApp.Guardian.encode_and_sign(resource, %{}, auth_time: true)
 ```
 
 Decoding tokens
@@ -165,6 +168,10 @@ Decoding tokens
 # Use a custom secret
 {:ok, claims} = MyApp.Guardian.decode_and_verify(token, %{}, secret: "custom")
 {:ok, claims} = MyApp.Guardian.decode_and_verify(token, %{}, secret: {SomeMod, :some_func, ["some", "args"]})
+
+# Specify a maximum age (since end user authentication time). If the token has an
+# `auth_time` claim and it is older than the `max_age` allows, the token will be invalid.
+{:ok, claims} = MyApp.Guardian.decode_and_verify(token, %{}, max_age: {2, :hours})
 ```
 
 If you need dynamic verification for JWT tokens, please see the documentation for `Guardian.Token.Jwt` and `Guardian.Token.Jwt.SecretFetcher`
@@ -219,7 +226,12 @@ The default token type of `Guardian` is JWT. It accepts many options but you rea
 * `allowed_drift` The drift that is allowed when decoding/verifying a token in milliseconds
 * `verify_issuer` Default false
 * `secret_fetcher` A module used to fetch the secret. Default: `Guardian.Token.Jwt.SecretFetcher`
+* `auth_time` Include an `auth_time` claim to denote the end user authentication time. Default false.
+* `max_age` Specify the maximum time (since the end user authentication) the token will be valid.
+  Format is the same as `ttl`. Implies `auth_time` unless `auth_time` is set explicitly to `false`.
 
+See the [OpenID Connect Core specification](https://openid.net/specs/openid-connect-core-1_0.html)
+for more details about `auth_time` and `max_age` behaviour.
 
 ## Secrets (JWT)
 

--- a/lib/guardian/plug/ensure_authenticated.ex
+++ b/lib/guardian/plug/ensure_authenticated.ex
@@ -17,6 +17,7 @@ if Code.ensure_loaded?(Plug) do
     Options:
 
     * `claims` - The literal claims to check to ensure that a token is valid
+    * `max_age` - If the token has an "auth_time" claim, check it is not older than the maximum age.
     * `key` - The location to find the information in the connection. Defaults to: `default`
     * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
 

--- a/lib/guardian/plug/verify_cookie.ex
+++ b/lib/guardian/plug/verify_cookie.ex
@@ -38,7 +38,7 @@ if Code.ensure_loaded?(Plug) do
     * `:exchange_from` - The type of the cookie (default `"refresh"`)
     * `:exchange_to` - The type of token to provide. Defaults to the implementation modules `default_type`
     * `:ttl` - The time to live of the exchanged token. Defaults to configured values.
-    * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
+    * `:halt` - Whether to halt the connection in case of error. Defaults to `true`.
     """
 
     import Plug.Conn

--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -30,6 +30,7 @@ if Code.ensure_loaded?(Plug) do
     Options:
 
     * `claims` - The literal claims to check to ensure that a token is valid
+    * `max_age` - If the token has an "auth_time" claim, check it is not older than the maximum age.
     * `header_name` - The name of the header to search for a token. Defaults to `authorization`.
     * `realm` - The prefix for the token in the header. Defaults to `Bearer`. `:none` will not use a prefix.
     * `key` - The location to store the information in the connection. Defaults to: `default`


### PR DESCRIPTION
Introduces the `auth_time` config and equivalent option, which makes `auth_time` an essential claim, and the `max_age` config and equivalent option, which introduces enforcement of a maximum time since end user authentication. The `max_age` config is the same format as `ttl` and `sliding_cookie`. The `auth_time` is maintained cross token exchange, though of course creating a new token outside such a context will by default reset it to the current (iat) time.

Configuring `max_age: {24, :hours}`, which implies `auth_time: true` will mean `Guardian.Plug.SlidingCookie` will only be able to chain tokens for 24 hours before  verify is failed and end user authentication is mandated.