### PR TITLE
The default for missing bits is empty list

### DIFF
--- a/lib/guardian/permissions.ex
+++ b/lib/guardian/permissions.ex
@@ -239,7 +239,7 @@ defmodule Guardian.Permissions do
         test_perms_bits = decode_permissions(test_perms)
 
         Enum.all?(test_perms_bits, fn {k, needs} ->
-          has = Map.get(has_perms_bits, k, 0)
+          has = Map.get(has_perms_bits, k, [])
           MapSet.subset?(MapSet.new(needs), MapSet.new(has))
         end)
       end


### PR DESCRIPTION
Zero as a default value was trying to be used in MapSet.new which is invalid
The normal return type is a list of atoms, so an empty list seems appropriate