### PR TITLE
Fix typing on Token.revoke callback

### DIFF
--- a/lib/guardian/token.ex
+++ b/lib/guardian/token.ex
@@ -68,7 +68,7 @@ defmodule Guardian.Token do
   Revoke a token (if appropriate)
   """
   @callback revoke(mod :: module, claims :: claims, token :: token, options :: Guardian.options()) ::
-              {:ok, claims | {:error, any}}
+              {:ok, claims} | {:error, any}
 
   @doc """
   Refresh a token


### PR DESCRIPTION
At least I presume this is what it's meant to be. The other way didn't make much sense.