### PR TITLE
Fix typo in tutorial

### DIFF
--- a/guides/tutorial/start-tutorial.md
+++ b/guides/tutorial/start-tutorial.md
@@ -105,7 +105,7 @@ defmodule AuthMe.UserManager.Guardian do
     user = UserManager.get_user!(id)
     {:ok, user}
   rescue
-    e in Ecto.NoResultsError => {:error, :resource_not_found}
+    e in Ecto.NoResultsError -> {:error, :resource_not_found}
   end
 end
 ```

--- a/guides/tutorial/start-tutorial.md
+++ b/guides/tutorial/start-tutorial.md
@@ -105,7 +105,7 @@ defmodule AuthMe.UserManager.Guardian do
     user = UserManager.get_user!(id)
     {:ok, user}
   rescue
-    e in Ecto.NoResultsError -> {:error, :resource_not_found}
+    Ecto.NoResultsError -> {:error, :resource_not_found}
   end
 end
 ```


### PR DESCRIPTION
I was completing the "Getting Started with Guardian" tutorial and noticed there was a typo and also an unused variable. This PR corrects that.

Thanks for Guardian!