### PR TITLE
Fix small typo in implementation docs

### DIFF
--- a/guides/introduction/implementation.md
+++ b/guides/introduction/implementation.md
@@ -36,7 +36,7 @@ When creating tokens, you can add custom claims to your tokens. The resulting to
 For example:
 
 ```elixir
-{:ok, token, full_claims = MyApp.TokenImpl.encode_and_sign(user, %{some: "data to store"})
+{:ok, token, full_claims} = MyApp.TokenImpl.encode_and_sign(user, %{some: "data to store"})
 ```
 
 ## Basic Setup


### PR DESCRIPTION
Found a super small typo in the implementation docs and I thought I might as well... fix it :smile: 