### PR TITLE
if a "kid" is included in the jwk, pass it to the jws as a hint

### DIFF
--- a/lib/guardian/token/jwt.ex
+++ b/lib/guardian/token/jwt.ex
@@ -395,7 +395,9 @@ defmodule Guardian.Token.Jwt do
     opts = Keyword.update(opts, :headers, header, &Map.merge(&1, header))
     jose_jws(mod, opts)
   end
+
   defp jose_jws(mod, _, opts), do: jose_jws(mod, opts)
+
   defp jose_jws(mod, opts) do
     algos = fetch_allowed_algos(mod, opts) || @default_algos
     headers = Keyword.get(opts, :headers, %{})

--- a/lib/guardian/token/jwt.ex
+++ b/lib/guardian/token/jwt.ex
@@ -135,6 +135,13 @@ defmodule Guardian.Token.Jwt do
     end
   end
   ```
+
+  If the signing secret contains a "kid" (https://tools.ietf.org/html/rfc7515#section-4.1.4)
+  it will be passed along to the signature to provide a hint about which secret was used.
+  This can be useful for specifying which public key to use during verification if you're using
+  a public/private key rotation strategy.
+  An example implementation of this can be found here: [https://gist.github.com/mpinkston/469009001b694d3ca162894d74c9bfe3](https://gist.github.com/mpinkston/469009001b694d3ca162894d74c9bfe3)
+
   """
 
   @behaviour Guardian.Token

--- a/test/guardian/token/jwt_test.exs
+++ b/test/guardian/token/jwt_test.exs
@@ -63,6 +63,7 @@ defmodule Guardian.Token.JwtTest do
       |> JOSE.JWS.compact()
 
     es512_jose_jwk = JOSE.JWK.generate_key({:ec, :secp521r1})
+    es512_jose_jwk = JOSE.JWK.merge(es512_jose_jwk, %{"kid" => JOSE.JWK.thumbprint(es512_jose_jwk)})
     es512_jose_jws = JOSE.JWS.from_map(%{"alg" => "ES512"})
 
     es512_jose_jwt =
@@ -131,7 +132,8 @@ defmodule Guardian.Token.JwtTest do
 
       {:ok, token} = Jwt.create_token(ctx.impl, ctx.claims, secret: secret, allowed_algos: ["ES512"])
 
-      {true, jwt, _} = JWT.verify_strict(secret, ["ES512"], token)
+      {true, jwt, jws} = JWT.verify_strict(secret, ["ES512"], token)
+      assert jws.fields["kid"] == secret.fields["kid"]
       assert jwt.fields == ctx.claims
 
       {:error, _reason} = JWT.verify_strict(ctx.impl.config(:secret_key), ["HS512"], token)


### PR DESCRIPTION
after implementing my own secret fetcher, I realized that the key id passed back in the JWK was not getting added to the signature.
As the secret frequently rotates, and the new key id is generated in the secret fetcher, there isn't a convenient place to pass the key id along in the `:headers` option.

This PR is to detect if a "kid" has been provided in the JWK and pass it along to the signature for easier lookups when there might be a list of more than one possible public key against which to verify. 

Please let me know if this looks like a reasonable approach.