### PR TITLE
Update test instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ For more in-depth documentation please see the [GuardianDb README](https://githu
 
 ### How to add the token to a request (the Phoenix way)
 
+Assuming you are using the default realm `Bearer` for the `Authorization` header:
+
 ```elixir
 defmodule HelloWeb.AuthControllerTest do
   use HelloWeb.ConnCase
@@ -436,7 +438,7 @@ defmodule HelloWeb.AuthControllerTest do
     {:ok, token, _} = encode_and_sign(user, %{}, token_type: :access)
 
     conn = conn
-    |> put_req_header("authorization", "bearer: " <> token)
+    |> put_req_header("authorization", "Bearer " <> token)
     |> get(auth_path(conn, :me))
 
     # Assert things here


### PR DESCRIPTION
The test instructions on the `README.md` file – for copy paste heads like myself – can lead the library user to a journey on the wrong side of the testing streets. 

This PR clarifies and fixes the instructions for the default behaviour of the lib, that probably 90% of the people use. 
Didn't look, but suspect that, at some point in the library history that was the default realm and it got carried on the `README.md` since. 

The root of the problem is probably a DRY violation between code and documentation (in this case the `README.md`). My fix is not ambitious enough to fix that problem.

Thanks for all the hard work on guardian. 🥇  