### PR TITLE
missing index/2 in PageController

### DIFF
--- a/guides/tutorial/start-tutorial.md
+++ b/guides/tutorial/start-tutorial.md
@@ -364,6 +364,10 @@ defmodule AuthMeWeb.PageController do
     user = Guardian.Plug.current_resource(conn)
     render(conn, "protected.html", current_user: user)
   end
+  
+  def index(conn, _params) do
+    render(conn, "index.html")
+  end
 end
 ```
 


### PR DESCRIPTION
Getting Started does not work, because this is not defined:

```
  # Maybe logged in routes
  scope "/", AuthMeWeb do
    pipe_through [:browser, :auth]

    get "/", PageController, :index <---- not defined in PageController!
```

So either change this

```
## lib/auth_me_web/controllers/page_controller.ex

defmodule AuthMeWeb.PageController do
  use AuthMeWeb, :controller

  def protected(conn, _) do
    user = Guardian.Plug.current_resource(conn)
    render(conn, "protected.html", current_user: user)
  end
end
```

to

"add this to PageController"
```
  def protected(conn, _) do
    user = Guardian.Plug.current_resource(conn)
    render(conn, "protected.html", current_user: user)
  end
```

or add add `index/2` (like in the PR).