### PR TITLE
chore: improve verify cookie options

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Look for a token in the header and verify it
 Look for a token in the session and verify it
 
 #### `Guardian.Plug.VerifyCookie`
+**NOTE**: this plug is deprecated. Please use `:verify_cookie` option in `Guardian.Plug.VerifyHeader` or `Guardian.Plug.VerifySession`
 
 Look for a token in cookies and exchange it for an access token
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Look for a token in the header and verify it
 Look for a token in the session and verify it
 
 #### `Guardian.Plug.VerifyCookie`
-**NOTE**: this plug is deprecated. Please use `:verify_cookie` option in `Guardian.Plug.VerifyHeader` or `Guardian.Plug.VerifySession`
+**NOTE**: this plug is deprecated. Please use `:refresh_from_cookie` option in `Guardian.Plug.VerifyHeader` or `Guardian.Plug.VerifySession`
 
 Look for a token in cookies and exchange it for an access token
 

--- a/lib/guardian/plug/verify_cookie.ex
+++ b/lib/guardian/plug/verify_cookie.ex
@@ -53,22 +53,22 @@ if Code.ensure_loaded?(Plug) do
 
     @impl Plug
     @spec init(opts :: Keyword.t()) :: Keyword.t()
-    @deprecated "Use Guardian.Plug.VerifySession or Guardian.Plug.VerifyHeader plug with `:verify_cookie` option."
+    @deprecated "Use Guardian.Plug.VerifySession or Guardian.Plug.VerifyHeader plug with `:refresh_from_cookie` option."
     def init(opts), do: opts
 
     @impl Plug
     @spec call(conn :: Plug.Conn.t(), opts :: Keyword.t()) :: Plug.Conn.t()
     def call(conn, opts) do
-      verify_cookie(conn, opts)
+      refresh_from_cookie(conn, opts)
     end
 
-    def verify_cookie(%{req_cookies: %Plug.Conn.Unfetched{}} = conn, opts) do
+    def refresh_from_cookie(%{req_cookies: %Plug.Conn.Unfetched{}} = conn, opts) do
       conn
       |> fetch_cookies()
-      |> verify_cookie(opts)
+      |> refresh_from_cookie(opts)
     end
 
-    def verify_cookie(conn, opts) do
+    def refresh_from_cookie(conn, opts) do
       with nil <- Guardian.Plug.current_token(conn, opts),
            {:ok, token} <- find_token_from_cookies(conn, opts),
            module <- Pipeline.fetch_module!(conn, opts),

--- a/lib/guardian/plug/verify_cookie.ex
+++ b/lib/guardian/plug/verify_cookie.ex
@@ -53,26 +53,33 @@ if Code.ensure_loaded?(Plug) do
 
     @impl Plug
     @spec init(opts :: Keyword.t()) :: Keyword.t()
+    @deprecated "Use Guardian.Plug.VerifySession or Guardian.Plug.VerifyHeader plug with `:verify_cookie` option."
     def init(opts), do: opts
 
     @impl Plug
     @spec call(conn :: Plug.Conn.t(), opts :: Keyword.t()) :: Plug.Conn.t()
-    def call(%{req_cookies: %Plug.Conn.Unfetched{}} = conn, opts) do
-      conn
-      |> fetch_cookies()
-      |> call(opts)
+    def call(conn, opts) do
+      verify_cookie(conn, opts)
     end
 
-    def call(conn, opts) do
+    def verify_cookie(%{req_cookies: %Plug.Conn.Unfetched{}} = conn, opts) do
+      conn
+      |> fetch_cookies()
+      |> verify_cookie(opts)
+    end
+
+    def verify_cookie(conn, opts) do
       with nil <- Guardian.Plug.current_token(conn, opts),
            {:ok, token} <- find_token_from_cookies(conn, opts),
            module <- Pipeline.fetch_module!(conn, opts),
            key <- storage_key(conn, opts),
-           exchange_from <- Keyword.get(opts, :exchange_from, "refresh"),
+           exchange_from <-
+             Keyword.get(opts, :exchange_from, "refresh"),
            default_type <- module.default_token_type(),
            exchange_to <- Keyword.get(opts, :exchange_to, default_type),
            active_session? <- Guardian.Plug.session_active?(conn),
-           {:ok, _old, {new_t, new_c}} <- Guardian.exchange(module, token, exchange_from, exchange_to, opts) do
+           {:ok, _old, {new_t, new_c}} <-
+             Guardian.exchange(module, token, exchange_from, exchange_to, opts) do
         conn
         |> Guardian.Plug.put_current_token(new_t, key: key)
         |> Guardian.Plug.put_current_claims(new_c, key: key)

--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -36,9 +36,9 @@ if Code.ensure_loaded?(Plug) do
       `:none` will not use a prefix.
     * `key` - The location to store the information in the connection. Defaults to: `default`
     * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
-    * `:verify_cookie` - Looks for and validates a token found in the request cookies. (default `false`)
+    * `:refresh_from_cookie` - Looks for and validates a token found in the request cookies. (default `false`)
 
-    Verify cookie option
+    Refresh from cookie option
 
     * `:key` - The location of the token (default `:default`)
     * `:exchange_from` - The type of the cookie (default `"refresh"`)
@@ -116,8 +116,8 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp handle_error(conn, :token_expired = reason, opts) do
-      if verify_cookie_opts = fetch_verify_cookie_options(opts) do
-        Guardian.Plug.VerifyCookie.verify_cookie(conn, verify_cookie_opts)
+      if refresh_from_cookie_opts = fetch_refresh_from_cookie_options(opts) do
+        Guardian.Plug.VerifyCookie.refresh_from_cookie(conn, refresh_from_cookie_opts)
       else
         apply_error(conn, reason, opts)
       end
@@ -134,8 +134,8 @@ if Code.ensure_loaded?(Plug) do
       |> Guardian.Plug.maybe_halt(opts)
     end
 
-    defp fetch_verify_cookie_options(opts) do
-      case Keyword.get(opts, :verify_cookie) do
+    defp fetch_refresh_from_cookie_options(opts) do
+      case Keyword.get(opts, :refresh_from_cookie) do
         value when is_list(value) -> value
         true -> []
         _ -> nil

--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -36,6 +36,16 @@ if Code.ensure_loaded?(Plug) do
       `:none` will not use a prefix.
     * `key` - The location to store the information in the connection. Defaults to: `default`
     * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
+    * `:verify_cookie` - Looks for and validates a token found in the request cookies. (default `false`)
+
+    Verify cookie option
+
+    * `:key` - The location of the token (default `:default`)
+    * `:exchange_from` - The type of the cookie (default `"refresh"`)
+    * `:exchange_to` - The type of token to provide. Defaults to the
+      implementation modules `default_type`
+    * `:ttl` - The time to live of the exchanged token. Defaults to configured values.
+    * `:halt` - Whether to halt the connection in case of error. Defaults to `true`
 
     ### Example
 

--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -64,13 +64,37 @@ if Code.ensure_loaded?(Plug) do
           conn
 
         {:error, reason} ->
-          conn
-          |> Pipeline.fetch_error_handler!(opts)
-          |> apply(:auth_error, [conn, {:invalid_token, reason}, opts])
-          |> Guardian.Plug.maybe_halt(opts)
+          handle_error(conn, reason, opts)
 
         _ ->
           conn
+      end
+    end
+
+    defp handle_error(conn, :token_expired = reason, opts) do
+      if verify_cookie_opts = fetch_verify_cookie_options(opts) do
+        Guardian.Plug.VerifyCookie.verify_cookie(conn, verify_cookie_opts)
+      else
+        apply_error(conn, reason, opts)
+      end
+    end
+
+    defp handle_error(conn, reason, opts) do
+      apply_error(conn, reason, opts)
+    end
+
+    defp apply_error(conn, reason, opts) do
+      conn
+      |> Pipeline.fetch_error_handler!(opts)
+      |> apply(:auth_error, [conn, {:invalid_token, reason}, opts])
+      |> Guardian.Plug.maybe_halt(opts)
+    end
+
+    defp fetch_verify_cookie_options(opts) do
+      case Keyword.get(opts, :verify_cookie) do
+        value when is_list(value) -> value
+        true -> []
+        _ -> nil
       end
     end
 

--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -29,9 +29,9 @@ if Code.ensure_loaded?(Plug) do
 
     Options:
 
-    * `:verify_cookie` - Looks for and validates a token found in the request cookies. (default `false`)
+    * `:refresh_from_cookie` - Looks for and validates a token found in the request cookies. (default `false`)
 
-    Verify cookie option
+    Refresh from cookie option
 
     * `:key` - The location of the token (default `:default`)
     * `:exchange_from` - The type of the cookie (default `"refresh"`)
@@ -85,8 +85,8 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp handle_error(conn, :token_expired = reason, opts) do
-      if verify_cookie_opts = fetch_verify_cookie_options(opts) do
-        Guardian.Plug.VerifyCookie.verify_cookie(conn, verify_cookie_opts)
+      if refresh_from_cookie_opts = fetch_refresh_from_cookie_options(opts) do
+        Guardian.Plug.VerifyCookie.refresh_from_cookie(conn, refresh_from_cookie_opts)
       else
         apply_error(conn, reason, opts)
       end
@@ -103,8 +103,8 @@ if Code.ensure_loaded?(Plug) do
       |> Guardian.Plug.maybe_halt(opts)
     end
 
-    defp fetch_verify_cookie_options(opts) do
-      case Keyword.get(opts, :verify_cookie) do
+    defp fetch_refresh_from_cookie_options(opts) do
+      case Keyword.get(opts, :refresh_from_cookie) do
         value when is_list(value) -> value
         true -> []
         _ -> nil

--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -26,6 +26,19 @@ if Code.ensure_loaded?(Plug) do
     be put onto the connection.
 
     They will be available using `Guardian.Plug.current_claims/2` and `Guardian.Plug.current_token/2`.
+
+    Options:
+
+    * `:verify_cookie` - Looks for and validates a token found in the request cookies. (default `false`)
+
+    Verify cookie option
+
+    * `:key` - The location of the token (default `:default`)
+    * `:exchange_from` - The type of the cookie (default `"refresh"`)
+    * `:exchange_to` - The type of token to provide. Defaults to the
+      implementation modules `default_type`
+    * `:ttl` - The time to live of the exchanged token. Defaults to configured values.
+    * `:halt` - Whether to halt the connection in case of error. Defaults to `true`
     """
 
     import Plug.Conn

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -173,7 +173,7 @@ defmodule Guardian.Plug.VerifyHeaderTest do
     refute conn.halted
   end
 
-  describe "with verify_cookie option" do
+  describe "with refresh_from_cookie option" do
     defmodule ImplJwt do
       @moduledoc false
 
@@ -223,7 +223,7 @@ defmodule Guardian.Plug.VerifyHeaderTest do
         :get
         |> conn("/")
         |> put_req_header("authorization", ctx.token)
-        |> VerifyHeader.call(module: ctx.impl, verify_cookie: [module: ctx.impl])
+        |> VerifyHeader.call(module: ctx.impl, refresh_from_cookie: [module: ctx.impl])
 
       assert Guardian.Plug.current_token(conn, []) == ctx.token
       assert Guardian.Plug.current_claims(conn, []) == ctx.claims
@@ -240,7 +240,7 @@ defmodule Guardian.Plug.VerifyHeaderTest do
         |> conn("/")
         |> put_req_cookie("guardian_default_token", refresh_token)
         |> put_req_header("authorization", expired_token)
-        |> VerifyHeader.call(module: ctx.impl, error_handler: ctx.handler, verify_cookie: [module: ctx.impl])
+        |> VerifyHeader.call(module: ctx.impl, error_handler: ctx.handler, refresh_from_cookie: [module: ctx.impl])
 
       refute conn.halted
       assert new_access_token = Guardian.Plug.current_token(conn)
@@ -258,7 +258,7 @@ defmodule Guardian.Plug.VerifyHeaderTest do
         |> conn("/")
         |> put_req_cookie("guardian_default_token", refresh_token)
         |> put_req_header("authorization", invalid_token)
-        |> VerifyHeader.call(module: ctx.impl, error_handler: ctx.handler, verify_cookie: [module: ctx.impl])
+        |> VerifyHeader.call(module: ctx.impl, error_handler: ctx.handler, refresh_from_cookie: [module: ctx.impl])
 
       assert conn.status == 401
       assert conn.halted

--- a/test/guardian/plug/verify_session_test.exs
+++ b/test/guardian/plug/verify_session_test.exs
@@ -248,7 +248,9 @@ defmodule Guardian.Plug.VerifySessionTest do
         :get
         |> conn("/")
         |> init_test_session(%{guardian_default_token: ctx.token})
-        |> VerifySession.call(module: ctx.impl, refresh_from_cookie: [module: ctx.impl])
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifySession.call(refresh_from_cookie: [])
 
       assert Guardian.Plug.current_token(conn, []) == ctx.token
       assert Guardian.Plug.current_claims(conn, []) == ctx.claims
@@ -265,7 +267,30 @@ defmodule Guardian.Plug.VerifySessionTest do
         |> conn("/")
         |> put_req_cookie("guardian_default_token", refresh_token)
         |> init_test_session(%{guardian_default_token: expired_token})
-        |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, refresh_from_cookie: [module: ctx.impl])
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifySession.call(refresh_from_cookie: [])
+
+      refute conn.halted
+      assert new_access_token = Guardian.Plug.current_token(conn)
+      assert {:ok, _} = apply(ctx.impl, :decode_and_verify, [new_access_token])
+      assert %{"sub" => "User:jane", "typ" => "access"} = Guardian.Plug.current_claims(conn)
+    end
+
+    test "when session is expired and refresh_from_cookie: true", ctx do
+      {:ok, expired_token, _} = apply(ctx.impl, :encode_and_sign, [%{id: "jane"}, %{}, [ttl: {0, :second}]])
+      {:ok, refresh_token, _} = apply(ctx.impl, :encode_and_sign, [%{id: "jane"}, %{}, [token_type: "refresh"]])
+      :timer.sleep(1000)
+      assert {:error, :token_expired} = apply(ctx.impl, :decode_and_verify, [expired_token])
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_cookie("guardian_default_token", refresh_token)
+        |> init_test_session(%{guardian_default_token: expired_token})
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifySession.call(refresh_from_cookie: true)
 
       refute conn.halted
       assert new_access_token = Guardian.Plug.current_token(conn)
@@ -283,7 +308,9 @@ defmodule Guardian.Plug.VerifySessionTest do
         |> conn("/")
         |> put_req_cookie("guardian_default_token", refresh_token)
         |> init_test_session(%{guardian_default_token: invalid_token})
-        |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, refresh_from_cookie: [module: ctx.impl])
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifySession.call(refresh_from_cookie: [])
 
       assert conn.status == 401
       assert conn.halted

--- a/test/guardian/plug/verify_session_test.exs
+++ b/test/guardian/plug/verify_session_test.exs
@@ -198,7 +198,7 @@ defmodule Guardian.Plug.VerifySessionTest do
     assert Guardian.Plug.current_claims(conn, key: :admin) == claims
   end
 
-  describe "with verify_cookie option" do
+  describe "with refresh_from_cookie option" do
     defmodule ImplJwt do
       @moduledoc false
 
@@ -248,7 +248,7 @@ defmodule Guardian.Plug.VerifySessionTest do
         :get
         |> conn("/")
         |> init_test_session(%{guardian_default_token: ctx.token})
-        |> VerifySession.call(module: ctx.impl, verify_cookie: [module: ctx.impl])
+        |> VerifySession.call(module: ctx.impl, refresh_from_cookie: [module: ctx.impl])
 
       assert Guardian.Plug.current_token(conn, []) == ctx.token
       assert Guardian.Plug.current_claims(conn, []) == ctx.claims
@@ -265,7 +265,7 @@ defmodule Guardian.Plug.VerifySessionTest do
         |> conn("/")
         |> put_req_cookie("guardian_default_token", refresh_token)
         |> init_test_session(%{guardian_default_token: expired_token})
-        |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, verify_cookie: [module: ctx.impl])
+        |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, refresh_from_cookie: [module: ctx.impl])
 
       refute conn.halted
       assert new_access_token = Guardian.Plug.current_token(conn)
@@ -283,7 +283,7 @@ defmodule Guardian.Plug.VerifySessionTest do
         |> conn("/")
         |> put_req_cookie("guardian_default_token", refresh_token)
         |> init_test_session(%{guardian_default_token: invalid_token})
-        |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, verify_cookie: [module: ctx.impl])
+        |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, refresh_from_cookie: [module: ctx.impl])
 
       assert conn.status == 401
       assert conn.halted

--- a/test/guardian/plug/verify_session_test.exs
+++ b/test/guardian/plug/verify_session_test.exs
@@ -197,4 +197,96 @@ defmodule Guardian.Plug.VerifySessionTest do
     assert Guardian.Plug.current_token(conn, key: :admin) == token
     assert Guardian.Plug.current_claims(conn, key: :admin) == claims
   end
+
+  describe "with verify_cookie option" do
+    defmodule ImplJwt do
+      @moduledoc false
+
+      use Guardian,
+        otp_app: :guardian,
+        token_module: Guardian.Token.Jwt,
+        issuer: "MyApp",
+        verify_issuer: true,
+        secret_key: "foo-de-fafa",
+        allowed_algos: ["HS512", "ES512"],
+        ttl: {4, :weeks},
+        secret_fetcher: Guardian.Support.TokenModule.SecretFetcher,
+        token_ttl: %{
+          "access" => {1, :day},
+          "refresh" => {2, :weeks}
+        },
+        handler: __MODULE__.Handler
+
+      def subject_for_token(%{id: id}, _claims), do: {:ok, "User:#{id}"}
+      def resource_from_claims(%{"sub" => "User:" <> sub}), do: {:ok, %{id: sub}}
+
+      def the_secret_yo, do: config(:secret_key)
+      def the_secret_yo(val), do: val
+
+      def verify_claims(claims, opts) do
+        if Keyword.get(opts, :fail_owner_verify_claims) do
+          {:error, Keyword.get(opts, :fail_owner_verify_claims)}
+        else
+          {:ok, claims}
+        end
+      end
+
+      def build_claims(claims, _opts) do
+        Map.put(claims, "from_owner", "here")
+      end
+    end
+
+    setup do
+      impl = __MODULE__.ImplJwt
+      handler = __MODULE__.Handler
+      {:ok, token, claims} = __MODULE__.ImplJwt.encode_and_sign(@resource)
+      {:ok, %{claims: claims, conn: conn(:get, "/"), token: token, impl: impl, handler: handler}}
+    end
+
+    test "when session is valid", ctx do
+      conn =
+        :get
+        |> conn("/")
+        |> init_test_session(%{guardian_default_token: ctx.token})
+        |> VerifySession.call(module: ctx.impl, verify_cookie: [module: ctx.impl])
+
+      assert Guardian.Plug.current_token(conn, []) == ctx.token
+      assert Guardian.Plug.current_claims(conn, []) == ctx.claims
+    end
+
+    test "when session is expired", ctx do
+      {:ok, expired_token, _} = apply(ctx.impl, :encode_and_sign, [%{id: "jane"}, %{}, [ttl: {0, :second}]])
+      {:ok, refresh_token, _} = apply(ctx.impl, :encode_and_sign, [%{id: "jane"}, %{}, [token_type: "refresh"]])
+      :timer.sleep(1000)
+      assert {:error, :token_expired} = apply(ctx.impl, :decode_and_verify, [expired_token])
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_cookie("guardian_default_token", refresh_token)
+        |> init_test_session(%{guardian_default_token: expired_token})
+        |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, verify_cookie: [module: ctx.impl])
+
+      refute conn.halted
+      assert new_access_token = Guardian.Plug.current_token(conn)
+      assert {:ok, _} = apply(ctx.impl, :decode_and_verify, [new_access_token])
+      assert %{"sub" => "User:jane", "typ" => "access"} = Guardian.Plug.current_claims(conn)
+    end
+
+    test "when session is invalid", ctx do
+      {:ok, token, _} = apply(ctx.impl, :encode_and_sign, [%{id: "jane"}])
+      invalid_token = "#{token}whatever"
+      {:ok, refresh_token, _} = apply(ctx.impl, :encode_and_sign, [%{id: "jane"}, %{}, [token_type: "refresh"]])
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_cookie("guardian_default_token", refresh_token)
+        |> init_test_session(%{guardian_default_token: invalid_token})
+        |> VerifySession.call(module: ctx.impl, error_handler: ctx.handler, verify_cookie: [module: ctx.impl])
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+  end
 end


### PR DESCRIPTION
Try to fix #668.

No breaking changes, only deprecate `Guardian.Plug.VerifyCookie` in favor of a `:verify_cookie` on `Guardian.Plug.VerifySession` and `Guardian.Plug.VerifyHeader` plugs