### PR TITLE
Allow multiple `resource_from_claims/1` signatures in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ To do this, create a module that uses `Guardian` and implements the `subject_for
 defmodule MyApp.Guardian do
   use Guardian, otp_app: :my_app
 
-  def subject_for_token(resource, _claims) do
+  def subject_for_token(%{id: id}, _claims) do
     # You can use any value for the subject of your token but
     # it should be useful in retrieving the resource later, see
     # how it being used on `resource_from_claims/1` function.
     # A unique `id` is a good subject, a non-unique email address
     # is a poor subject.
-    sub = to_string(resource.id)
+    sub = to_string(id)
     {:ok, sub}
   end
   def subject_for_token(_, _) do


### PR DESCRIPTION
The way the `subject_for_token/1` and  `resource_from_claims/1` examples in the readme are currently written, no call would ever reach their error paths, as there is no pattern to match against in each preceding signature, and those would therefore act as the catchall case.