### PR TITLE
Corrects Plug.Verify presentation on pipelines.md

### DIFF
--- a/guides/plug/pipelines.md
+++ b/guides/plug/pipelines.md
@@ -32,7 +32,7 @@ The next thing that we're going to want to do is find the token. Guardian provid
 
 * [VerifySession](Guardian.Plug.VerifySession.html) - For when the token is stored in the session
 * [VerifyHeader](Guardian.Plug.VerifyHeader.html) - `Authorization` header token location
-* [VerifyCookie](Guardian.Plug.VerifyCookie.html) - A cookie has the cookie stored
+* [VerifyCookie](Guardian.Plug.VerifyCookie.html) - A cookie has the token stored
 
 ```elixir
 # ...


### PR DESCRIPTION
When presenting the function `Guardian.Plug.VerifyCookie`, the documentation says: "A cookie has the cookie stored". It is supposed to say "A cookie has the token stored".