### PR TITLE
Ensure that badly-formatted tokens don't raise an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.2.3
+
+### Enhancement
+
+* Ensure that badly-formatted tokens don't raise an exception when attempting to decode them.
+
 ## v2.2.2
 
 ### Enhancement

--- a/lib/guardian/token/jwt.ex
+++ b/lib/guardian/token/jwt.ex
@@ -239,6 +239,8 @@ defmodule Guardian.Token.Jwt do
 
   def peek(_mod, token) do
     %{headers: JWT.peek_protected(token).fields, claims: JWT.peek_payload(token).fields}
+  rescue
+    ArgumentError -> nil
   end
 
   @doc """
@@ -329,6 +331,8 @@ defmodule Guardian.Token.Jwt do
         {true, jose_jwt, _} -> {:ok, jose_jwt.fields}
         {false, _, _} -> {:error, :invalid_token}
       end
+    else
+      _ -> {:error, :invalid_token}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Guardian.Mixfile do
   @moduledoc false
   use Mix.Project
 
-  @version "2.2.2"
+  @version "2.2.3"
   @url "https://github.com/ueberauth/guardian"
   @maintainers [
     "Daniel Neighman",

--- a/test/guardian/token/jwt_test.exs
+++ b/test/guardian/token/jwt_test.exs
@@ -185,6 +185,12 @@ defmodule Guardian.Token.JwtTest do
       assert {:ok, ctx.claims} == result
     end
 
+    test "does not verify with a bad token format", ctx do
+      secret = ctx.es512.jwk
+      result = Jwt.decode_token(ctx.impl, "badtoken", secret: secret)
+      assert {:error, :invalid_token} == result
+    end
+
     test "it decodes the jwt with an {m, f, a}", ctx do
       the_secret = ctx.impl.config(:secret_key)
       secret = {ctx.impl, :the_secret_yo, [the_secret]}


### PR DESCRIPTION
It seems that `JOSE` likes to raise `ArgumentError`s when it encounters badly-formatted tokens. Since Guardian returns an `:ok | :error` tuple when decoding tokens, it seems sensible to catch these exceptions where possible.