### PR TITLE
Fix deprecation warnings based on 1.14

### DIFF
--- a/lib/guardian/plug/pipeline.ex
+++ b/lib/guardian/plug/pipeline.ex
@@ -145,7 +145,7 @@ if Code.ensure_loaded?(Plug) do
 
             otp_app ->
               otp_app
-              |> Application.get_env(__MODULE__, [])
+              |> Application.compile_env(__MODULE__, [])
               |> Keyword.merge(opts)
           end
         end


### PR DESCRIPTION
Similar to this PR: #702, when adding `use Guardian, otp_app: :api` to a module, we see the same warning:

`warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead`

Also `mix compile --force --warnings-as-errors` is a requirement for our CI pipeline.
