### PR TITLE
doc: Clarify session storage behavior on sign_in in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ Congrats! We have a working Guardian implementation.
 With Plug:
 
 ```elixir
-# If a session is loaded the token/resource/claims will be put into the session and connection
-# If no session is loaded, the token/resource/claims only go onto the connection
+# The token/resource/claims will be stored on the connection.
+# The token will also be stored in the session (if fetched)
 conn = MyApp.Guardian.Plug.sign_in(conn, resource)
 
 # Optionally with claims and options


### PR DESCRIPTION
This clarifies that only the token is stored on the session when `Guardian.Plug.sign_in` is called - the claims and resource are not. See implementation [here](https://github.com/ueberauth/guardian/blob/d46795513fc36938e563fa2fc601392e4871baaf/lib/guardian/plug.ex#L209).