### PR TITLE
Users should be able to change most config values at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.1
+
+* Change compile time loading of configuration to only load permissions
+  allowing the app to change things like ttl or secret key at runtime
+
 ## v2.3.0
 
 * Fix warning about the usage of `Application.get_env` in the module scope

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -341,7 +341,7 @@ defmodule Guardian do
       the_opts = unquote(opts)
 
       # Provide a way to get at the permissions during compile time. Uses
-      # permissions from config if they are available and falss back to the
+      # permissions from config if they are available and falls back to the
       # permissins defined on the `use Guardian` implementation
       #
       # NOTE: Generally you can't use compile_env for most keys because that

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -352,6 +352,7 @@ defmodule Guardian do
         perms =
           Application.compile_env(the_otp_app, [__MODULE__, :permissions]) ||
             Keyword.get(the_opts, :permissions, [])
+
         Guardian.Config.resolve_value(perms)
       end
 

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -349,7 +349,8 @@ defmodule Guardian do
       # environements.And hardcoding secret keys wouldn't be considered a good
       # practice.
       @config_permissions fn ->
-        the_otp_app |> Application.compile_env([__MODULE__, :permissions]) || Keyword.get(the_opts, :permissions, []) |> Guardian.Config.resolve_value()
+        the_otp_app |> Application.compile_env([__MODULE__, :permissions]) ||
+          Keyword.get(the_opts, :permissions, []) |> Guardian.Config.resolve_value()
       end
 
       @doc """

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -340,16 +340,16 @@ defmodule Guardian do
       the_otp_app = unquote(otp_app)
       the_opts = unquote(opts)
 
-      # Provide a way to get at the configuration during compile time
-      # for other macros that may want to use them
-      @config fn ->
-        the_otp_app |> Application.compile_env(__MODULE__, []) |> Keyword.merge(the_opts)
-      end
-      @config_with_key fn key ->
-        @config.() |> Keyword.get(key) |> Guardian.Config.resolve_value()
-      end
-      @config_with_key_and_default fn key, default ->
-        @config.() |> Keyword.get(key, default) |> Guardian.Config.resolve_value()
+      # Provide a way to get at the permissions during compile time. Uses
+      # permissions from config if they are available and falss back to the
+      # permissins defined on the `use Guardian` implementation
+      #
+      # NOTE: Generally you can't use compile_env for most keys because that
+      # would prevent people from changing them at runtime for differen
+      # environements.And hardcoding secret keys wouldn't be considered a good
+      # practice.
+      @config_permissions fn ->
+        the_otp_app |> Application.compile_env([__MODULE__, :permissions]) || Keyword.get(the_opts, :permissions, []) |> Guardian.Config.resolve_value()
       end
 
       @doc """

--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -349,8 +349,10 @@ defmodule Guardian do
       # environements.And hardcoding secret keys wouldn't be considered a good
       # practice.
       @config_permissions fn ->
-        the_otp_app |> Application.compile_env([__MODULE__, :permissions]) ||
-          Keyword.get(the_opts, :permissions, []) |> Guardian.Config.resolve_value()
+        perms =
+          Application.compile_env(the_otp_app, [__MODULE__, :permissions]) ||
+            Keyword.get(the_opts, :permissions, [])
+        Guardian.Config.resolve_value(perms)
       end
 
       @doc """

--- a/lib/guardian/permissions.ex
+++ b/lib/guardian/permissions.ex
@@ -137,7 +137,7 @@ defmodule Guardian.Permissions do
 
       defdelegate max(), to: Guardian.Permissions
 
-      raw_perms = @config_with_key.(:permissions)
+      raw_perms = @config_permissions.()
 
       unless raw_perms do
         raise "Permissions are not defined for #{to_string(__MODULE__)}"

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Guardian.Mixfile do
   @moduledoc false
   use Mix.Project
 
-  @version "2.3.0"
+  @version "2.3.1"
   @url "https://github.com/ueberauth/guardian"
   @maintainers [
     "Daniel Neighman",


### PR DESCRIPTION
Permissions are used at compile time, but other config variables should be read at runtime so that they can be overridden at runtime vs compile time. This allows for 12 Factor type deployment

This is intended to fix: #706 

Existing tests pass, but I'm not really sure how to write a test for this exact issue.
* `Application.put_env` in a test doesn't trigger the error. 
* Tried adding a test.exs and a runtime.exs with different values but couldn't trigger it either.
 
Happy to get some help on how to test that and update this PR