### PR TITLE
fix: codegen token must use base64url encoding

### DIFF
--- a/lib/mix/tasks/guardian.gen.secret.ex
+++ b/lib/mix/tasks/guardian.gen.secret.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Guardian.Gen.Secret do
   end
 
   defp random_string(length) when length > 31 do
-    length |> :crypto.strong_rand_bytes() |> Base.encode64() |> binary_part(0, length)
+    length |> :crypto.strong_rand_bytes() |> Base.url_encode64() |> binary_part(0, length)
   end
 
   defp random_string(_), do: Mix.raise("The secret should be at least 32 characters long")


### PR DESCRIPTION
closes #718

> The "k" (key value) parameter contains the value of the symmetric (or
   other single-valued) key.  It is represented as the **base64url**
   encoding of the octet sequence containing the key value.

https://www.rfc-editor.org/rfc/rfc7518.html#section-6.4.1