### PR TITLE
header_name should always be downcase

### DIFF
--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -152,7 +152,9 @@ if Code.ensure_loaded?(Plug) do
             :no_token_found
             | {:ok, String.t()}
     defp fetch_token_from_header(conn, opts) do
-      header_name = Keyword.get(opts, :header_name, "authorization")
+      header_name =
+        Keyword.get(opts, :header_name, "authorization")
+        |> String.downcase
       headers = get_req_header(conn, header_name)
       fetch_token_from_header(conn, opts, headers)
     end


### PR DESCRIPTION
get_req_header will never match for uppercase headers.

If a header_name is provided and is uppercase it will never match the header. Instead of simply documenting it, we should just assert that the header we are looking for is always downcase to prevent footguns.