### PR TITLE
Fix error when authorization header is nil

### DIFF
--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -162,6 +162,10 @@ if Code.ensure_loaded?(Plug) do
             | {:ok, String.t()}
     defp fetch_token_from_header(_, _, []), do: :no_token_found
 
+    defp fetch_token_from_header(conn, opts, [token | tail]) when not is_binary(token) do
+      fetch_token_from_header(conn, opts, tail)
+    end
+
     defp fetch_token_from_header(conn, opts, [token | tail]) do
       reg = Keyword.get(opts, :scheme_reg, ~r/^(.*)$/)
       trimmed_token = String.trim(token)

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -53,6 +53,18 @@ defmodule Guardian.Plug.VerifyHeaderTest do
     assert Guardian.Plug.current_claims(conn, []) == nil
   end
 
+  test "with nil in the authorization header" do
+    conn =
+      :get
+      |> conn("/")
+      |> Map.put(:req_headers, [{"authorization", nil}])
+      |> VerifyHeader.call([])
+
+    refute conn.status == 401
+    assert Guardian.Plug.current_token(conn, []) == nil
+    assert Guardian.Plug.current_claims(conn, []) == nil
+  end
+
   test "it uses the module from options", ctx do
     conn =
       :get


### PR DESCRIPTION
Fix error with Bandit when a client sends an empty Authorization header.

```
** (FunctionClauseError) no function clause matching in String.trim/1
    (elixir 1.16.2) lib/string.ex:1293: String.trim(nil)
    (guardian 2.3.2) lib/guardian/plug/verify_header.ex:167: Guardian.Plug.VerifyHeader.fetch_token_from_header/3
    (guardian 2.3.2) lib/guardian/plug/verify_header.ex:88: Guardian.Plug.VerifyHeader.call/2
    (api 0.0.1) ApiWeb.Router.guardian/2
    (api 0.0.1) lib/api_web/router.ex:1: ApiWeb.Router.__pipe_through0__/1
    (phoenix 1.7.12) lib/phoenix/router.ex:475: Phoenix.Router.__call__/5
    (api 0.0.1) deps/plug/lib/plug/error_handler.ex:80: ApiWeb.Router.call/2
    (api 0.0.1) lib/api_web/endpoint.ex:1: ApiWeb.Endpoint.plug_builder_call/2
Last message: {:continue, :start_stream}
```
