### PR TITLE
refactor: deprecate use of unless

### DIFF
--- a/lib/guardian/permissions.ex
+++ b/lib/guardian/permissions.ex
@@ -139,7 +139,7 @@ defmodule Guardian.Permissions do
 
       raw_perms = @config_permissions.()
 
-      unless raw_perms do
+      if !raw_perms do
         raise "Permissions are not defined for #{to_string(__MODULE__)}"
       end
 

--- a/lib/guardian/plug/pipeline.ex
+++ b/lib/guardian/plug/pipeline.ex
@@ -133,7 +133,7 @@ if Code.ensure_loaded?(Plug) do
             |> Keyword.merge(unquote(opts))
             |> config()
 
-          unless Keyword.get(new_opts, :otp_app), do: raise_error(:otp_app)
+          if !Keyword.get(new_opts, :otp_app), do: raise_error(:otp_app)
 
           new_opts
         end


### PR DESCRIPTION
As I was implementing Guardian in my project, I noticed the use of `unless/2` in the codebase. I had heard that the language was deprecating `unless/2` moving forward in 1.18 and later as verified [here](https://github.com/elixir-lang/elixir/pull/13851)