### PR TITLE
Add day ttl option in encode_and_sign doc

### DIFF
--- a/lib/guardian.ex
+++ b/lib/guardian.ex
@@ -580,6 +580,7 @@ defmodule Guardian do
   * `:second` | `:seconds`
   * `:minute` | `:minutes`
   * `:hour` | `:hours`
+  * `:day` | `:days`
   * `:week` | `:weeks`
 
   See the documentation for your implementation / token module for more information on


### PR DESCRIPTION
Hey there, little `encode_and_sign` documentation fix according to this `ttl_to_second` clause:

```elixir
def ttl_to_seconds({days, unit}) when unit in [:day, :days],
  do: days * 24 * 60 * 60
```