### PR TITLE
Fix VerifyToken compilation under OTP 28 by allowing binary scheme_reg

### DIFF
--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -108,8 +108,7 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp put_scheme_reg(scheme, opts) do
-      {:ok, reg} = Regex.compile("#{scheme}\:?\s+(.*)$", "i")
-      Keyword.put(opts, :scheme_reg, reg)
+      Keyword.put(opts, :scheme_reg, "#{scheme}\:?\s+(.*)$")
     end
 
     defp get_scheme(opts) do
@@ -163,7 +162,12 @@ if Code.ensure_loaded?(Plug) do
     defp fetch_token_from_header(_, _, []), do: :no_token_found
 
     defp fetch_token_from_header(conn, opts, [token | tail]) do
-      reg = Keyword.get(opts, :scheme_reg, ~r/^(.*)$/)
+      reg =
+        case Keyword.get(opts, :scheme_reg, ~r/^(.*)$/) do
+          %Regex{} = reg -> reg
+          reg_str -> Regex.compile!(reg_str, "i")
+        end
+
       trimmed_token = String.trim(token)
 
       case Regex.run(reg, trimmed_token) do


### PR DESCRIPTION
There is an issue with the new regex implementation in OTP28 causing Guardian.Plug.VerifyHeader not to compile (See #737 )

I could make out [this Regex.compile call](https://github.com/ueberauth/guardian/blob/37a911c9954df75ea96d474067b0fb482131f7cd/lib/guardian/plug/verify_header.ex#L111) as the source of the problem.

Allowing `opts[:scheme_reg]` to be a string and calling `Regex.compile` later seems to make it work while also keeping changes to a minimum.

I wanted to share a possible solution should it be useful. I am not sure how elegant a solution this really is and problems with [jose](https://github.com/potatosalad/erlang-jose/issues/179) will keep the current state of being fully compatible with OTP28 at the moment.