### PR TITLE
Reject non-numeric JWT time claims

### DIFF
--- a/lib/guardian/token/jwt/verify.ex
+++ b/lib/guardian/token/jwt/verify.ex
@@ -28,6 +28,9 @@ defmodule Guardian.Token.Jwt.Verify do
 
   def verify_claim(_mod, "nbf", %{"nbf" => nil} = claims, _opts), do: {:ok, claims}
 
+  def verify_claim(_mod, "nbf", %{"nbf" => nbf}, _opts) when not is_number(nbf),
+    do: {:error, :invalid_token}
+
   def verify_claim(mod, "nbf", %{"nbf" => nbf} = claims, _opts) do
     if Verify.time_within_drift?(mod, nbf) || nbf <= Guardian.timestamp() do
       {:ok, claims}
@@ -38,6 +41,9 @@ defmodule Guardian.Token.Jwt.Verify do
 
   def verify_claim(_mod, "exp", %{"exp" => nil} = claims, _opts), do: {:ok, claims}
 
+  def verify_claim(_mod, "exp", %{"exp" => exp}, _opts) when not is_number(exp),
+    do: {:error, :invalid_token}
+
   def verify_claim(mod, "exp", %{"exp" => exp} = claims, _opts) do
     if Verify.time_within_drift?(mod, exp) || exp >= Guardian.timestamp() do
       {:ok, claims}
@@ -47,6 +53,9 @@ defmodule Guardian.Token.Jwt.Verify do
   end
 
   def verify_claim(_mod, "auth_time", %{"auth_time" => nil} = claims, _opts), do: {:ok, claims}
+
+  def verify_claim(_mod, "auth_time", %{"auth_time" => auth_time}, _opts) when not is_number(auth_time),
+    do: {:error, :invalid_token}
 
   def verify_claim(mod, "auth_time", %{"auth_time" => auth_time} = claims, opts) do
     max_age = opts[:max_age] || mod.config(:max_age)

--- a/lib/guardian/token/verify.ex
+++ b/lib/guardian/token/verify.ex
@@ -55,7 +55,7 @@ defmodule Guardian.Token.Verify do
     diff <= allowed_drift
   end
 
-  def time_within_drift?(_, _), do: true
+  def time_within_drift?(_, _), do: false
 
   @spec verify_literal_claims(
           claims :: Guardian.Token.claims(),

--- a/test/guardian/token/jwt_test.exs
+++ b/test/guardian/token/jwt_test.exs
@@ -393,6 +393,11 @@ defmodule Guardian.Token.JwtTest do
       assert {:error, :token_expired} = Jwt.verify_claims(ctx.impl, claims, [])
     end
 
+    test "it is invalid when exp is not numeric", ctx do
+      claims = Map.put(ctx.claims, "exp", "tomorrow")
+      assert {:error, :invalid_token} = Jwt.verify_claims(ctx.impl, claims, [])
+    end
+
     test "it is invalid when nbf is too late", ctx do
       claims = Map.put(ctx.claims, "nbf", Guardian.timestamp() + 5)
       assert {:error, :token_not_yet_valid} = Jwt.verify_claims(ctx.impl, claims, [])
@@ -401,6 +406,11 @@ defmodule Guardian.Token.JwtTest do
     test "it is invalid when nbf is a float and too late", ctx do
       claims = Map.put(ctx.claims, "nbf", Guardian.timestamp() * 1.0 + 5)
       assert {:error, :token_not_yet_valid} = Jwt.verify_claims(ctx.impl, claims, [])
+    end
+
+    test "it is invalid when nbf is not numeric", ctx do
+      claims = Map.put(ctx.claims, "nbf", "tomorrow")
+      assert {:error, :invalid_token} = Jwt.verify_claims(ctx.impl, claims, [])
     end
 
     test "it is invalid when the issuer is not correct", ctx do
@@ -432,6 +442,11 @@ defmodule Guardian.Token.JwtTest do
     test "it is invalid when max_age is specified and auth_time is too old", ctx do
       assert {:error, :token_expired} = Jwt.verify_claims(ctx.impl, ctx.claims, max_age: {1, :second})
       assert {:error, :token_expired} = Jwt.verify_claims(ctx.impl, ctx.claims, max_age: {2, :second})
+    end
+
+    test "it is invalid when auth_time is not numeric", ctx do
+      claims = Map.put(ctx.claims, "auth_time", "yesterday")
+      assert {:error, :invalid_token} = Jwt.verify_claims(ctx.impl, claims, max_age: {1, :hour})
     end
   end
 

--- a/test/guardian/token/verify_test.exs
+++ b/test/guardian/token/verify_test.exs
@@ -5,6 +5,16 @@ defmodule Guardian.Token.VerifyTest do
 
   alias Guardian.Token.Verify
 
+  defmodule Config do
+    def config(:allowed_drift, _default), do: 0
+  end
+
+  describe "time_within_drift?/2" do
+    test "returns false for a non-numeric time" do
+      refute Verify.time_within_drift?(Config, "tomorrow")
+    end
+  end
+
   describe "test verify_literal_claims/3" do
     test "claims_to_check are nil" do
       claims = %{aud: "api_audience"}


### PR DESCRIPTION
I found this while testing Guardian tokens used for both HTTP requests and aPhoenix socket

A signed token with `exp` set to `"tomorrow"` was accepted by `decode_and_verify/1`. I checked `nbf` and `auth_time` as well and found the same behavior

The fallback in `time_within_drift?/2` returns `true` when the value is not a number. Because of that, malformed time claims can pass verification without going through the normal timestamp checks

This adds type checks for the time claims Guardian already verifies. Integers and floats keep working as before, while other values return `:invalid_token`. The existing behavior for `nil` is unchanged

I added tests for `exp`, `nbf`, `auth_time`, and the drift helper. The full test suite passes with 245 tests