### PR TITLE
fix(ci): scope the build cache to the toolchain that produced it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-otp-${{ matrix.versions.otp }}-elixir-${{ matrix.versions.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-
+            ${{ runner.os }}-otp-${{ matrix.versions.otp }}-elixir-${{ matrix.versions.elixir }}-mix-
 
       - name: Set up Elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ on:
 jobs:
   Test:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    name: OTP ${{matrix.versions.otp}} / Elixir ${{matrix.versions.elixir}}
     strategy:
+      fail-fast: false
       matrix:
         versions:
           - elixir: "1.16"
@@ -57,7 +58,7 @@ jobs:
 
   Linting:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}} Linting
+    name: Linting
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6


### PR DESCRIPTION
- Every matrix job shared one cache entry covering `deps` **and** `_build`, since the key carried no Elixir/OTP version. Jobs restored bytecode compiled by a different toolchain, which crashes the compiler on unreadable beam chunks: [`beam_lib.read_chunk_data/3` badarg while type-checking `Plug.Telemetry.call/2`](https://github.com/ueberauth/guardian/actions/runs/31998200502/job/95293594450) on Elixir 1.17.
- With fail-fast on, one red or transient job cancels every other version, so a single failure erases the signal from the whole run and hides whether the problem is version-specific.
- The matrix key is `versions`, so `matrix.otp`/`matrix.elixir` never resolved and every job rendered as "OTP  / Elixir", making failures impossible to identify from the checks list.