### PR TITLE
fix(test): stop asserting atom safety against a global VM counter

### DIFF
--- a/test/guardian/permissions/atom_encoding_test.exs
+++ b/test/guardian/permissions/atom_encoding_test.exs
@@ -71,11 +71,13 @@ defmodule Guardian.Permissions.AtomEncodingTest do
     test "it does not create atoms for attacker-supplied binaries" do
       attacker = for i <- 1..5_000, do: "attacker_perm_#{i}"
 
-      before = :erlang.system_info(:atom_count)
       assert AtomEncoding.encode(attacker, "default", @perm_set) == []
-      after_count = :erlang.system_info(:atom_count)
 
-      assert after_count - before == 0
+      for permission <- attacker do
+        assert_raise ArgumentError, ~r/not an already existing atom/, fn ->
+          String.to_existing_atom(permission)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
- `atom_encoding_test.exs` reads `:erlang.system_info(:atom_count)`, a VM-wide counter, from an `async: true` module, so an atom created by any test running alongside it fails the assertion. It has been failing on master since #741 and lands on unrelated PRs, with a different Elixir/OTP job failing each run because the outcome depends on scheduling rather than on the version.
- Asserting that the attacker-supplied binaries never became atoms covers the same intent without depending on global VM state. Confirmed still meaningful by reintroducing the bug: with `String.to_atom/1` in `encode_value/3`, the test fails.