### PR TITLE
feat(plug): select the verifying secret from the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
   Supported by `Guardian.Plug.VerifyHeader`, `Guardian.Plug.VerifySession` and
   `Guardian.Plug.VerifyCookie`, and exposed as `Guardian.Plug.resolve_secret/2`
-  for custom plugs.
+  for custom plugs. A `:secret` function of any other arity raises an
+  `ArgumentError` instead of reaching the token module.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Documentation
+
+* Document that the verify plugs forward unrecognized options to
+  `Guardian.decode_and_verify/4`, including `Guardian.Token.Jwt`'s `:secret`,
+  and add a "Runtime secrets" guide covering per-tenant verifying secrets. Note
+  that a `nil` `:secret` falls back to the implementation module's
+  `:secret_key` rather than failing, so runtime lookups must fail closed
+  ([#690](https://github.com/ueberauth/guardian/issues/690)).
+
 ## v2.4.1
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,41 @@
 
 ## Unreleased
 
+### Added
+
+* The verify plugs accept a one argument function for `:secret`, called with the
+  connection to select a verifying secret per request. This covers multitenant
+  setups where each tenant has its own key
+  ([#690](https://github.com/ueberauth/guardian/issues/690)).
+
+      plug Guardian.Plug.VerifyHeader, secret: &MyApp.Secrets.for_conn/1
+
+  Supported by `Guardian.Plug.VerifyHeader`, `Guardian.Plug.VerifySession` and
+  `Guardian.Plug.VerifyCookie`, and exposed as `Guardian.Plug.resolve_secret/2`
+  for custom plugs.
+
+### Changed
+
+* **Behaviour change.** `Guardian.Token.Jwt` no longer falls back to the
+  implementation module's `:secret_key` when an explicitly provided `:secret`
+  is `nil`, or when a `{module, function, args}` secret resolves to `nil`. Both
+  now fail with `{:error, :secret_not_found}`. Previously a runtime secret
+  lookup that returned `nil` would silently sign or verify with the application
+  wide secret, which defeats tenant isolation when third party issued tokens
+  and application issued tokens share an implementation module. Omitting
+  `:secret` entirely still uses `:secret_key` as before.
+
+* `Guardian.Token.Jwt.decode_token/3` propagates `{:error, :secret_not_found}`
+  instead of reporting it as `{:error, :invalid_token}`, so a missing runtime
+  secret is distinguishable from a bad signature. Error handlers matching on
+  `{:invalid_token, :invalid_token}` for this case should also match
+  `{:invalid_token, :secret_not_found}`.
+
 ### Documentation
 
 * Document that the verify plugs forward unrecognized options to
   `Guardian.decode_and_verify/4`, including `Guardian.Token.Jwt`'s `:secret`,
-  and add a "Runtime secrets" guide covering per-tenant verifying secrets. Note
-  that a `nil` `:secret` falls back to the implementation module's
-  `:secret_key` rather than failing, so runtime lookups must fail closed
-  ([#690](https://github.com/ueberauth/guardian/issues/690)).
+  and add a "Runtime secrets" guide covering per-tenant verifying secrets.
 
 ## v2.4.1
 

--- a/guides/plug/runtime-secrets.md
+++ b/guides/plug/runtime-secrets.md
@@ -27,14 +27,39 @@ plug Guardian.Plug.VerifyHeader, secret: &MyApp.Secrets.for_conn/1
 
 ```elixir
 defmodule MyApp.Secrets do
-  def for_conn(conn) do
-    case JOSE.JWK.from_pem(conn.assigns.current_tenant.public_key) do
-      %JOSE.JWK{} = jwk -> jwk
-      _ -> nil
+  def for_conn(conn), do: conn.assigns[:tenant_jwk]
+end
+```
+
+Keep the function a cheap read off the connection. Do the loading and parsing once, upstream,
+where the result can be assigned and reused:
+
+```elixir
+defmodule MyAppWeb.LoadTenant do
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _opts) do
+    tenant = MyApp.Tenants.from_slug!(conn.params["tenant_slug"])
+
+    case JOSE.JWK.from_pem(tenant.public_key) do
+      %JOSE.JWK{} = jwk -> conn |> assign(:current_tenant, tenant) |> assign(:tenant_jwk, jwk)
+      _ -> assign(conn, :current_tenant, tenant)
     end
   end
 end
 ```
+
+Parsing a PEM is not free, and neither is a database or JWKS round trip. A verify plug resolves
+`:secret` once per request, and only after it has found a token, so a request carrying no token
+never calls the function at all. It can run a second time if you configure `:secret` on both a
+verify plug and its `:refresh_from_cookie` options, since the refresh is a separate exchange.
+Treat the function as something that may run more than once and should not perform I/O.
 
 Use a remote capture such as `&MyApp.Secrets.for_conn/1`. `Plug.Builder` and Phoenix router
 pipelines call `init/1` at compile time and inline the result, and an anonymous function cannot be
@@ -51,6 +76,18 @@ pipeline :api_auth do
   plug Guardian.Plug.VerifyHeader, secret: &MyApp.Secrets.for_conn/1
   plug Guardian.Plug.EnsureAuthenticated
 end
+```
+
+### Refreshing from a cookie
+
+`:refresh_from_cookie` is configured with its own options, and they are not inherited from the
+plug that triggered the refresh. A `:secret` on the verify plug therefore does not reach the token
+exchange, which falls back to the implementation module's `:secret_key`. Set it in both places:
+
+```elixir
+plug Guardian.Plug.VerifyHeader,
+  secret: &MyApp.Secrets.for_conn/1,
+  refresh_from_cookie: [secret: &MyApp.Secrets.for_conn/1]
 ```
 
 ### A nil secret fails closed

--- a/guides/plug/runtime-secrets.md
+++ b/guides/plug/runtime-secrets.md
@@ -12,28 +12,22 @@ module's `:secret_key` configuration:
 plug Guardian.Plug.VerifyHeader, secret: "a-secret-for-this-endpoint"
 ```
 
-That is enough when the secret is static. It is not enough for multitenancy, because plug options
-are built once by `init/1` at compile time and cannot see the connection.
+That is enough when the secret is static. Plug options are built once by `init/1` at compile time,
+so a literal value cannot depend on the request.
 
 ## Selecting a secret per request
 
-Plugs compose, so wrap the Guardian plug and merge the secret into its options at call time:
+Give `:secret` a one argument function. The verify plugs call it with the connection and use what
+it returns:
 
 ```elixir
-defmodule MyAppWeb.VerifyHeader do
-  @behaviour Plug
+plug MyAppWeb.LoadTenant
+plug Guardian.Plug.VerifyHeader, secret: &MyApp.Secrets.for_conn/1
+```
 
-  alias Guardian.Plug.VerifyHeader
-
-  @impl Plug
-  def init(opts), do: VerifyHeader.init(opts)
-
-  @impl Plug
-  def call(conn, opts) do
-    VerifyHeader.call(conn, Keyword.put(opts, :secret, verifying_secret(conn)))
-  end
-
-  defp verifying_secret(conn) do
+```elixir
+defmodule MyApp.Secrets do
+  def for_conn(conn) do
     case JOSE.JWK.from_pem(conn.assigns.current_tenant.public_key) do
       %JOSE.JWK{} = jwk -> jwk
       _ -> nil
@@ -42,57 +36,50 @@ defmodule MyAppWeb.VerifyHeader do
 end
 ```
 
-Call `VerifyHeader.init/1` from your own `init/1`. It compiles the `:scheme` option into the
-regular expression the plug uses to strip the `Bearer` prefix, and skipping it changes how tokens
-are matched.
+Use a remote capture such as `&MyApp.Secrets.for_conn/1`. `Plug.Builder` and Phoenix router
+pipelines call `init/1` at compile time and inline the result, and an anonymous function cannot be
+inlined. Writing `secret: fn conn -> ... end` or `secret: & &1.assigns.tenant.key` in a `plug`
+line fails to compile with `cannot escape #Function<...>`. Both forms are fine when you call
+`VerifyHeader.call/2` yourself, or under `use Plug.Builder, init_mode: :runtime`.
 
-Use your plug wherever you would have used the Guardian one, downstream of whatever assigns the
-tenant:
+This works on `Guardian.Plug.VerifyHeader`, `Guardian.Plug.VerifySession` and
+`Guardian.Plug.VerifyCookie`. Place it downstream of whatever resolves the tenant:
 
 ```elixir
 pipeline :api_auth do
   plug MyAppWeb.LoadTenant
-  plug MyAppWeb.VerifyHeader
+  plug Guardian.Plug.VerifyHeader, secret: &MyApp.Secrets.for_conn/1
   plug Guardian.Plug.EnsureAuthenticated
 end
 ```
 
-## Do not let the secret be nil
+### A nil secret fails closed
 
-A `nil` secret is not treated as an error. `Guardian.Token.Jwt` falls back to the implementation
-module's `:secret_key` configuration whenever the resolved `:secret` is `nil`, so a tenant lookup
-that quietly fails will verify tokens against your application-wide secret instead of the tenant's
-key. If both an application-wide secret and third-party tenant keys are in play, that is a tenant
-isolation failure rather than a rejected request.
+Returning `nil` rejects the request with `{:invalid_token, :secret_not_found}`. It does **not**
+fall back to the implementation module's `:secret_key`, so a tenant lookup that quietly fails
+cannot end up verifying tokens against your application wide secret.
 
-Fail closed instead of passing `nil` down:
+Guardian versions before this behaviour change did fall back. If you were selecting secrets at
+runtime with a wrapper plug, check whether your code relied on that fallback for requests with no
+tenant.
 
-```elixir
-import Plug.Conn
+## Other option forms
 
-@impl Plug
-def call(conn, opts) do
-  case verifying_secret(conn) do
-    nil -> conn |> resp(401, "") |> halt()
-    secret -> VerifyHeader.call(conn, Keyword.put(opts, :secret, secret))
-  end
-end
-```
-
-Routing the rejection through the pipeline's error handler works too:
+`:secret` also accepts a `{module, function, args}` tuple, resolved by
+`Guardian.Config.resolve_value/1`:
 
 ```elixir
-nil ->
-  conn
-  |> Guardian.Plug.Pipeline.fetch_error_handler!(opts)
-  |> apply(:auth_error, [conn, {:invalid_token, :secret_not_found}, opts])
-  |> halt()
+plug Guardian.Plug.VerifyHeader, secret: {MyApp.Vault, :fetch, ["api-signing-key"]}
 ```
+
+The arguments are fixed at compile time and the connection is not passed, so this suits a secret
+read from a vault or environment rather than one that varies per request. Use the one argument
+function form when the choice depends on the connection.
 
 ## Choosing a secret from the token headers
 
 If the secret depends on the token rather than on the connection (a `kid` header pointing into a
-JWKS, for example), you do not need a plug at all. Implement a
+JWKS, for example), you do not need a plug option at all. Implement a
 `Guardian.Token.Jwt.SecretFetcher` and configure it on your implementation module:
 
 ```elixir
@@ -114,12 +101,27 @@ end
 config :my_app, MyApp.Guardian, secret_fetcher: MyApp.SecretFetcher
 ```
 
-The two approaches compose. A secret fetcher receives the options the plug was called with, so a
-wrapper plug can pass tenant information through to it:
+Unlike the plug option, a secret fetcher also covers token creation and applies everywhere the
+implementation module is used, not only behind a plug.
+
+## Combining the two
+
+A secret fetcher receives the options the plug was called with, so the plug can pass connection
+derived context through to it. Any option accepts this, not just `:secret`:
 
 ```elixir
-def call(conn, opts) do
-  VerifyHeader.call(conn, Keyword.put(opts, :tenant, conn.assigns.current_tenant))
+defmodule MyAppWeb.VerifyTenantToken do
+  @behaviour Plug
+
+  alias Guardian.Plug.VerifyHeader
+
+  @impl Plug
+  def init(opts), do: VerifyHeader.init(opts)
+
+  @impl Plug
+  def call(conn, opts) do
+    VerifyHeader.call(conn, Keyword.put(opts, :tenant, conn.assigns.current_tenant))
+  end
 end
 ```
 
@@ -130,3 +132,8 @@ def fetch_verifying_secret(_mod, %{"kid" => kid}, opts) do
   |> MyApp.JWKS.fetch(kid)
 end
 ```
+
+Wrapping a verify plug like this is also the escape hatch for anything other than `:secret` that
+has to vary per request. Call the wrapped plug's `init/1` from your own: `VerifyHeader.init/1`
+compiles the `:scheme` option into the regular expression used to strip the `Bearer` prefix, and
+skipping it changes how tokens are matched.

--- a/guides/plug/runtime-secrets.md
+++ b/guides/plug/runtime-secrets.md
@@ -104,36 +104,16 @@ config :my_app, MyApp.Guardian, secret_fetcher: MyApp.SecretFetcher
 Unlike the plug option, a secret fetcher also covers token creation and applies everywhere the
 implementation module is used, not only behind a plug.
 
-## Combining the two
+## Which one to reach for
 
-A secret fetcher receives the options the plug was called with, so the plug can pass connection
-derived context through to it. Any option accepts this, not just `:secret`:
+The plug option sees the connection. The secret fetcher sees the token headers. Pick whichever
+holds the information your lookup needs, and prefer the plug option when either would work, since
+it keeps the choice visible at the pipeline.
 
-```elixir
-defmodule MyAppWeb.VerifyTenantToken do
-  @behaviour Plug
+If a lookup genuinely needs both, note that a secret fetcher also receives the options the plug was
+called with, so connection derived context can be handed to it through any option name.
 
-  alias Guardian.Plug.VerifyHeader
-
-  @impl Plug
-  def init(opts), do: VerifyHeader.init(opts)
-
-  @impl Plug
-  def call(conn, opts) do
-    VerifyHeader.call(conn, Keyword.put(opts, :tenant, conn.assigns.current_tenant))
-  end
-end
-```
-
-```elixir
-def fetch_verifying_secret(_mod, %{"kid" => kid}, opts) do
-  opts
-  |> Keyword.fetch!(:tenant)
-  |> MyApp.JWKS.fetch(kid)
-end
-```
-
-Wrapping a verify plug like this is also the escape hatch for anything other than `:secret` that
-has to vary per request. Call the wrapped plug's `init/1` from your own: `VerifyHeader.init/1`
-compiles the `:scheme` option into the regular expression used to strip the `Bearer` prefix, and
-skipping it changes how tokens are matched.
+Options other than `:secret` still have no connection aware form. Varying those per request means
+wrapping the verify plug in your own, in which case delegate to the wrapped plug's `init/1`:
+`VerifyHeader.init/1` compiles the `:scheme` option into the regular expression used to strip the
+`Bearer` prefix, and skipping it changes how tokens are matched.

--- a/guides/plug/runtime-secrets.md
+++ b/guides/plug/runtime-secrets.md
@@ -1,0 +1,132 @@
+# Runtime secrets
+
+Some applications cannot know the verifying secret at compile time. The common case is
+multitenancy: tokens are issued and signed by a third party, and each tenant has its own public
+key. The key to verify with is only known once the request has been resolved to a tenant.
+
+The verify plugs forward any unrecognized option to `Guardian.decode_and_verify/4`, and from there
+to the token module. For `Guardian.Token.Jwt`, a `:secret` option overrides the implementation
+module's `:secret_key` configuration:
+
+```elixir
+plug Guardian.Plug.VerifyHeader, secret: "a-secret-for-this-endpoint"
+```
+
+That is enough when the secret is static. It is not enough for multitenancy, because plug options
+are built once by `init/1` at compile time and cannot see the connection.
+
+## Selecting a secret per request
+
+Plugs compose, so wrap the Guardian plug and merge the secret into its options at call time:
+
+```elixir
+defmodule MyAppWeb.VerifyHeader do
+  @behaviour Plug
+
+  alias Guardian.Plug.VerifyHeader
+
+  @impl Plug
+  def init(opts), do: VerifyHeader.init(opts)
+
+  @impl Plug
+  def call(conn, opts) do
+    VerifyHeader.call(conn, Keyword.put(opts, :secret, verifying_secret(conn)))
+  end
+
+  defp verifying_secret(conn) do
+    case JOSE.JWK.from_pem(conn.assigns.current_tenant.public_key) do
+      %JOSE.JWK{} = jwk -> jwk
+      _ -> nil
+    end
+  end
+end
+```
+
+Call `VerifyHeader.init/1` from your own `init/1`. It compiles the `:scheme` option into the
+regular expression the plug uses to strip the `Bearer` prefix, and skipping it changes how tokens
+are matched.
+
+Use your plug wherever you would have used the Guardian one, downstream of whatever assigns the
+tenant:
+
+```elixir
+pipeline :api_auth do
+  plug MyAppWeb.LoadTenant
+  plug MyAppWeb.VerifyHeader
+  plug Guardian.Plug.EnsureAuthenticated
+end
+```
+
+## Do not let the secret be nil
+
+A `nil` secret is not treated as an error. `Guardian.Token.Jwt` falls back to the implementation
+module's `:secret_key` configuration whenever the resolved `:secret` is `nil`, so a tenant lookup
+that quietly fails will verify tokens against your application-wide secret instead of the tenant's
+key. If both an application-wide secret and third-party tenant keys are in play, that is a tenant
+isolation failure rather than a rejected request.
+
+Fail closed instead of passing `nil` down:
+
+```elixir
+import Plug.Conn
+
+@impl Plug
+def call(conn, opts) do
+  case verifying_secret(conn) do
+    nil -> conn |> resp(401, "") |> halt()
+    secret -> VerifyHeader.call(conn, Keyword.put(opts, :secret, secret))
+  end
+end
+```
+
+Routing the rejection through the pipeline's error handler works too:
+
+```elixir
+nil ->
+  conn
+  |> Guardian.Plug.Pipeline.fetch_error_handler!(opts)
+  |> apply(:auth_error, [conn, {:invalid_token, :secret_not_found}, opts])
+  |> halt()
+```
+
+## Choosing a secret from the token headers
+
+If the secret depends on the token rather than on the connection (a `kid` header pointing into a
+JWKS, for example), you do not need a plug at all. Implement a
+`Guardian.Token.Jwt.SecretFetcher` and configure it on your implementation module:
+
+```elixir
+defmodule MyApp.SecretFetcher do
+  use Guardian.Token.Jwt.SecretFetcher
+
+  def fetch_verifying_secret(_mod, %{"kid" => kid}, _opts) do
+    case MyApp.JWKS.fetch(kid) do
+      {:ok, jwk} -> {:ok, jwk}
+      :error -> {:error, :secret_not_found}
+    end
+  end
+
+  def fetch_verifying_secret(_mod, _headers, _opts), do: {:error, :secret_not_found}
+end
+```
+
+```elixir
+config :my_app, MyApp.Guardian, secret_fetcher: MyApp.SecretFetcher
+```
+
+The two approaches compose. A secret fetcher receives the options the plug was called with, so a
+wrapper plug can pass tenant information through to it:
+
+```elixir
+def call(conn, opts) do
+  VerifyHeader.call(conn, Keyword.put(opts, :tenant, conn.assigns.current_tenant))
+end
+```
+
+```elixir
+def fetch_verifying_secret(_mod, %{"kid" => kid}, opts) do
+  opts
+  |> Keyword.fetch!(:tenant)
+  |> MyApp.JWKS.fetch(kid)
+end
+```

--- a/guides/plug/runtime-secrets.md
+++ b/guides/plug/runtime-secrets.md
@@ -113,6 +113,9 @@ The arguments are fixed at compile time and the connection is not passed, so thi
 read from a vault or environment rather than one that varies per request. Use the one argument
 function form when the choice depends on the connection.
 
+One argument is the only function form accepted. Any other arity raises an `ArgumentError` from
+the plug rather than reaching the token module, where it would surface as an opaque JOSE failure.
+
 ## Choosing a secret from the token headers
 
 If the secret depends on the token rather than on the connection (a `kid` header pointing into a

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -138,7 +138,8 @@ if Code.ensure_loaded?(Plug) do
     fails to compile.
 
     Every other value is left untouched, including `{module, function, args}` tuples, which are
-    resolved later by `Guardian.Config.resolve_value/1` without access to the connection.
+    resolved later by `Guardian.Config.resolve_value/1` without access to the connection. A
+    function of any other arity raises, since no token module can make sense of it.
 
     Returning `nil` is an error rather than a fallback to the implementation module's
     `:secret_key`. See `Guardian.Token.Jwt`.
@@ -154,8 +155,15 @@ if Code.ensure_loaded?(Plug) do
     @spec resolve_secret(Plug.Conn.t(), Guardian.options()) :: Guardian.options()
     def resolve_secret(conn, opts) do
       case Keyword.fetch(opts, :secret) do
-        {:ok, fun} when is_function(fun, 1) -> Keyword.put(opts, :secret, fun.(conn))
-        _ -> opts
+        {:ok, fun} when is_function(fun, 1) ->
+          Keyword.put(opts, :secret, fun.(conn))
+
+        {:ok, fun} when is_function(fun) ->
+          raise ArgumentError,
+                "the :secret option must be a function of one argument, got: #{inspect(fun)}"
+
+        _ ->
+          opts
       end
     end
 

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -143,6 +143,11 @@ if Code.ensure_loaded?(Plug) do
     Returning `nil` is an error rather than a fallback to the implementation module's
     `:secret_key`. See `Guardian.Token.Jwt`.
 
+    A verify plug resolves the secret once per request, after it has found a token, so a request
+    carrying no token never calls the function. It can run more than once when `:secret` is also
+    configured on `:refresh_from_cookie`. Keep it a cheap read off the connection and do any
+    loading or parsing in an upstream plug.
+
     The verify plugs call this on your behalf. It is public so that custom plugs can offer the
     same option.
     """

--- a/lib/guardian/plug.ex
+++ b/lib/guardian/plug.ex
@@ -124,6 +124,36 @@ if Code.ensure_loaded?(Plug) do
     @spec default_key() :: String.t()
     def default_key, do: @default_key
 
+    @doc """
+    Resolves a connection aware `:secret` option to a concrete value.
+
+    Plug options are built once by `init/1`, so a static `:secret` cannot depend on the request.
+    Giving `:secret` a one argument function defers the decision to call time: the function
+    receives the connection and returns the secret to use.
+
+        plug Guardian.Plug.VerifyHeader, secret: &MyApp.Secrets.for_conn/1
+
+    Use a remote capture. `Plug.Builder` inlines the result of a compile time `init/1`, and an
+    anonymous function cannot be inlined, so `secret: & &1.assigns.tenant.key` in a `plug` line
+    fails to compile.
+
+    Every other value is left untouched, including `{module, function, args}` tuples, which are
+    resolved later by `Guardian.Config.resolve_value/1` without access to the connection.
+
+    Returning `nil` is an error rather than a fallback to the implementation module's
+    `:secret_key`. See `Guardian.Token.Jwt`.
+
+    The verify plugs call this on your behalf. It is public so that custom plugs can offer the
+    same option.
+    """
+    @spec resolve_secret(Plug.Conn.t(), Guardian.options()) :: Guardian.options()
+    def resolve_secret(conn, opts) do
+      case Keyword.fetch(opts, :secret) do
+        {:ok, fun} when is_function(fun, 1) -> Keyword.put(opts, :secret, fun.(conn))
+        _ -> opts
+      end
+    end
+
     @spec current_claims(Plug.Conn.t(), Guardian.options()) :: Guardian.Token.claims() | nil
     def current_claims(conn, opts \\ []) do
       key =

--- a/lib/guardian/plug/verify_cookie.ex
+++ b/lib/guardian/plug/verify_cookie.ex
@@ -82,8 +82,9 @@ if Code.ensure_loaded?(Plug) do
            default_type <- module.default_token_type(),
            exchange_to <- Keyword.get(opts, :exchange_to, default_type),
            active_session? <- Guardian.Plug.session_active?(conn),
+           exchange_opts <- Guardian.Plug.resolve_secret(conn, opts),
            {:ok, _old, {new_t, new_c}} <-
-             Guardian.exchange(module, token, exchange_from, exchange_to, opts) do
+             Guardian.exchange(module, token, exchange_from, exchange_to, exchange_opts) do
         conn
         |> Guardian.Plug.put_current_token(new_t, key: key)
         |> Guardian.Plug.put_current_claims(new_c, key: key)

--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -38,6 +38,17 @@ if Code.ensure_loaded?(Plug) do
     * `halt` - Whether to halt the connection in case of error. Defaults to `true`.
     * `:refresh_from_cookie` - Looks for and validates a token found in the request cookies. (default `false`)
 
+    Any other option is forwarded to `Guardian.decode_and_verify/4`, and from there to the token
+    module. For `Guardian.Token.Jwt` this includes:
+
+    * `secret` - The secret used to verify the token, overriding the implementation module's
+      `:secret_key` configuration. Accepts any value resolvable by `Guardian.Config`, including
+      a `{module, function, args}` tuple.
+
+    Because plug options are built once at compile time, a static `:secret` cannot depend on the
+    request. To select a secret per request (per tenant, per issuer), see
+    [Runtime secrets](plug-runtime-secrets.html).
+
     Refresh from cookie option
 
     * `:key` - The location of the token (default `:default`)

--- a/lib/guardian/plug/verify_header.ex
+++ b/lib/guardian/plug/verify_header.ex
@@ -43,11 +43,9 @@ if Code.ensure_loaded?(Plug) do
 
     * `secret` - The secret used to verify the token, overriding the implementation module's
       `:secret_key` configuration. Accepts any value resolvable by `Guardian.Config`, including
-      a `{module, function, args}` tuple.
-
-    Because plug options are built once at compile time, a static `:secret` cannot depend on the
-    request. To select a secret per request (per tenant, per issuer), see
-    [Runtime secrets](plug-runtime-secrets.html).
+      a `{module, function, args}` tuple, or a one argument function that receives the connection
+      and returns the secret. See `Guardian.Plug.resolve_secret/2` and
+      [Runtime secrets](plug-runtime-secrets.html).
 
     Refresh from cookie option
 
@@ -100,7 +98,8 @@ if Code.ensure_loaded?(Plug) do
            module <- Pipeline.fetch_module!(conn, opts),
            claims_to_check <- Keyword.get(opts, :claims, %{}),
            key <- storage_key(conn, opts),
-           {:ok, claims} <- Guardian.decode_and_verify(module, token, claims_to_check, opts) do
+           verify_opts <- Guardian.Plug.resolve_secret(conn, opts),
+           {:ok, claims} <- Guardian.decode_and_verify(module, token, claims_to_check, verify_opts) do
         conn
         |> Guardian.Plug.put_current_token(token, key: key)
         |> Guardian.Plug.put_current_claims(claims, key: key)

--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -32,6 +32,17 @@ if Code.ensure_loaded?(Plug) do
 
     * `:refresh_from_cookie` - Looks for and validates a token found in the request cookies. (default `false`)
 
+    Any other option is forwarded to `Guardian.decode_and_verify/4`, and from there to the token
+    module. For `Guardian.Token.Jwt` this includes:
+
+    * `secret` - The secret used to verify the token, overriding the implementation module's
+      `:secret_key` configuration. Accepts any value resolvable by `Guardian.Config`, including
+      a `{module, function, args}` tuple.
+
+    Because plug options are built once at compile time, a static `:secret` cannot depend on the
+    request. To select a secret per request (per tenant, per issuer), see
+    [Runtime secrets](plug-runtime-secrets.html).
+
     Refresh from cookie option
 
     * `:key` - The location of the token (default `:default`)

--- a/lib/guardian/plug/verify_session.ex
+++ b/lib/guardian/plug/verify_session.ex
@@ -37,11 +37,9 @@ if Code.ensure_loaded?(Plug) do
 
     * `secret` - The secret used to verify the token, overriding the implementation module's
       `:secret_key` configuration. Accepts any value resolvable by `Guardian.Config`, including
-      a `{module, function, args}` tuple.
-
-    Because plug options are built once at compile time, a static `:secret` cannot depend on the
-    request. To select a secret per request (per tenant, per issuer), see
-    [Runtime secrets](plug-runtime-secrets.html).
+      a `{module, function, args}` tuple, or a one argument function that receives the connection
+      and returns the secret. See `Guardian.Plug.resolve_secret/2` and
+      [Runtime secrets](plug-runtime-secrets.html).
 
     Refresh from cookie option
 
@@ -80,7 +78,8 @@ if Code.ensure_loaded?(Plug) do
            module <- Pipeline.fetch_module!(conn, opts),
            claims_to_check <- Keyword.get(opts, :claims, %{}),
            key <- storage_key(conn, opts),
-           {:ok, claims} <- Guardian.decode_and_verify(module, token, claims_to_check, opts) do
+           verify_opts <- Guardian.Plug.resolve_secret(conn, opts),
+           {:ok, claims} <- Guardian.decode_and_verify(module, token, claims_to_check, verify_opts) do
         conn
         |> Guardian.Plug.put_current_token(token, key: key)
         |> Guardian.Plug.put_current_claims(claims, key: key)

--- a/lib/guardian/token/jwt.ex
+++ b/lib/guardian/token/jwt.ex
@@ -40,6 +40,11 @@ defmodule Guardian.Token.Jwt do
   * `token_type` - Override the default token type. The default is "access"
   * `ttl` - The time to live. See `Guardian.Token.ttl` type
 
+  The `secret_key` configuration is only consulted when the `:secret` option is absent. Providing
+  `:secret` explicitly always wins, and a `:secret` that is (or resolves to) `nil` fails with
+  `{:error, :secret_not_found}` rather than falling back to `secret_key`. This keeps a failed
+  runtime lookup from silently verifying or signing with the application wide secret.
+
   #### Example
 
   ```elixir
@@ -210,22 +215,23 @@ defmodule Guardian.Token.Jwt do
     use Guardian.Token.Jwt.SecretFetcher
 
     def fetch_signing_secret(mod, opts) do
-      secret = Keyword.get(opts, :secret)
-      secret = Config.resolve_value(secret) || apply(mod, :config, [:secret_key])
-
-      case secret do
+      case fetch_secret(mod, opts) do
         nil -> {:error, :secret_not_found}
         val -> {:ok, val}
       end
     end
 
     def fetch_verifying_secret(mod, _token_headers, opts) do
-      secret = Keyword.get(opts, :secret)
-      secret = Config.resolve_value(secret) || mod.config(:secret_key)
-
-      case secret do
+      case fetch_secret(mod, opts) do
         nil -> {:error, :secret_not_found}
         val -> {:ok, val}
+      end
+    end
+
+    defp fetch_secret(mod, opts) do
+      case Keyword.fetch(opts, :secret) do
+        {:ok, secret} -> Config.resolve_value(secret)
+        :error -> mod.config(:secret_key)
       end
     end
   end
@@ -332,6 +338,7 @@ defmodule Guardian.Token.Jwt do
         {false, _, _} -> {:error, :invalid_token}
       end
     else
+      {:error, :secret_not_found} = error -> error
       _ -> {:error, :invalid_token}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -107,6 +107,10 @@ defmodule Guardian.Mixfile do
         filename: "plug-pipelines",
         title: "Pipelines"
       ],
+      "guides/plug/runtime-secrets.md": [
+        filename: "plug-runtime-secrets",
+        title: "Runtime secrets"
+      ],
       "guides/phoenix/start-phoenix.md": [
         filename: "phoenix-start",
         title: "Start"

--- a/test/guardian/plug/verify_cookie_test.exs
+++ b/test/guardian/plug/verify_cookie_test.exs
@@ -140,6 +140,67 @@ defmodule Guardian.Plug.VerifyCookieTest do
     end
   end
 
+  describe "with a runtime secret" do
+    @tenant_secret "tenant-secret-key"
+
+    defmodule SecretImpl do
+      @moduledoc false
+
+      use Guardian,
+        otp_app: :guardian,
+        token_module: Guardian.Token.Jwt,
+        secret_key: "configured-secret-key",
+        allowed_algos: ["HS512"]
+
+      def subject_for_token(%{id: id}, _claims), do: {:ok, id}
+      def resource_from_claims(%{"sub" => id}), do: {:ok, %{id: id}}
+    end
+
+    setup do
+      impl = __MODULE__.SecretImpl
+      handler = __MODULE__.Handler
+
+      {:ok, token, _claims} =
+        __MODULE__.SecretImpl.encode_and_sign(@resource, %{}, token_type: "refresh", secret: @tenant_secret)
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_cookie("guardian_default_token", token)
+        |> fetch_cookies()
+        |> assign(:tenant_secret, @tenant_secret)
+        |> Pipeline.put_module(impl)
+        |> Pipeline.put_error_handler(handler)
+
+      {:ok, %{conn: conn, token: token}}
+    end
+
+    test "the exchange uses a connection aware :secret", ctx do
+      conn = VerifyCookie.call(ctx.conn, secret: & &1.assigns.tenant_secret)
+
+      refute conn.halted
+      assert new_token = Guardian.Plug.current_token(conn, [])
+      refute new_token == ctx.token
+      assert Guardian.Plug.current_claims(conn, [])["typ"] == "access"
+
+      assert {:ok, _claims} = SecretImpl.decode_and_verify(new_token, %{}, secret: @tenant_secret)
+    end
+
+    test "without the :secret option the exchange fails", ctx do
+      conn = VerifyCookie.call(ctx.conn, [])
+
+      assert conn.halted
+      assert {401, _, "{:invalid_token, :invalid_token}"} = sent_resp(conn)
+    end
+
+    test "a connection aware :secret returning nil fails closed", ctx do
+      conn = VerifyCookie.call(ctx.conn, secret: & &1.assigns[:missing_secret])
+
+      assert conn.halted
+      assert {401, _, "{:invalid_token, :secret_not_found}"} = sent_resp(conn)
+    end
+  end
+
   describe "with verify session" do
     setup %{conn: conn, impl: impl, handler: handler} do
       conn =

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -372,7 +372,7 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       def resource_from_claims(%{"sub" => id}), do: {:ok, %{id: id}}
     end
 
-    defmodule TenantVerifyHeader do
+    defmodule VerifyTenantToken do
       @moduledoc false
 
       @behaviour Plug
@@ -446,7 +446,7 @@ defmodule Guardian.Plug.VerifyHeaderTest do
     end
 
     test "a wrapping plug can derive the secret from the connection", ctx do
-      opts = TenantVerifyHeader.init([])
+      opts = VerifyTenantToken.init([])
 
       conn =
         :get
@@ -455,21 +455,72 @@ defmodule Guardian.Plug.VerifyHeaderTest do
         |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
         |> Pipeline.put_module(ctx.impl)
         |> Pipeline.put_error_handler(ctx.handler)
-        |> TenantVerifyHeader.call(opts)
+        |> VerifyTenantToken.call(opts)
 
       refute conn.halted
       assert Guardian.Plug.current_claims(conn, []) == ctx.tenant_claims
     end
 
-    test "a nil :secret falls back to the implementation module secret", ctx do
+    test "a nil :secret fails closed instead of falling back to the module secret", ctx do
       conn = call_with(ctx, ctx.configured_token, secret: nil)
 
-      refute conn.halted
-      assert Guardian.Plug.current_token(conn, []) == ctx.configured_token
+      assert conn.status == 401
+      assert conn.resp_body == inspect({:invalid_token, :secret_not_found})
+      assert Guardian.Plug.current_token(conn, []) == nil
     end
 
-    test "a wrapping plug that finds no secret does not verify the tenant token", ctx do
-      opts = TenantVerifyHeader.init([])
+    test "the :secret option accepts a function of the connection", ctx do
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
+        |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifyHeader.call(VerifyHeader.init(secret: & &1.assigns.tenant_secret))
+
+      refute conn.halted
+      assert Guardian.Plug.current_claims(conn, []) == ctx.tenant_claims
+    end
+
+    test "a connection aware :secret returning nil fails closed", ctx do
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifyHeader.call(VerifyHeader.init(secret: & &1.assigns[:tenant_secret]))
+
+      assert conn.status == 401
+      assert conn.resp_body == inspect({:invalid_token, :secret_not_found})
+    end
+
+    test "a connection aware :secret survives a compiled plug pipeline", ctx do
+      defmodule TenantPipeline do
+        @moduledoc false
+        use Plug.Builder
+
+        plug(Guardian.Plug.VerifyHeader, secret: &__MODULE__.tenant_secret/1)
+
+        def tenant_secret(conn), do: conn.assigns[:tenant_secret]
+      end
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
+        |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> TenantPipeline.call(TenantPipeline.init([]))
+
+      refute conn.halted
+      assert Guardian.Plug.current_claims(conn, []) == ctx.tenant_claims
+    end
+
+    test "a wrapping plug can still derive the secret from the connection", ctx do
+      opts = VerifyTenantToken.init([])
 
       conn =
         :get
@@ -477,10 +528,10 @@ defmodule Guardian.Plug.VerifyHeaderTest do
         |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
         |> Pipeline.put_module(ctx.impl)
         |> Pipeline.put_error_handler(ctx.handler)
-        |> TenantVerifyHeader.call(opts)
+        |> VerifyTenantToken.call(opts)
 
       assert conn.status == 401
-      assert conn.resp_body == inspect({:invalid_token, :invalid_token})
+      assert conn.resp_body == inspect({:invalid_token, :secret_not_found})
     end
   end
 end

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -372,20 +372,6 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       def resource_from_claims(%{"sub" => id}), do: {:ok, %{id: id}}
     end
 
-    defmodule VerifyTenantToken do
-      @moduledoc false
-
-      @behaviour Plug
-
-      @impl Plug
-      def init(opts), do: VerifyHeader.init(opts)
-
-      @impl Plug
-      def call(conn, opts) do
-        VerifyHeader.call(conn, Keyword.put(opts, :secret, conn.assigns[:tenant_secret]))
-      end
-    end
-
     def tenant_secret, do: @tenant_secret
 
     setup do
@@ -445,22 +431,6 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       assert Guardian.Plug.current_token(conn, []) == nil
     end
 
-    test "a wrapping plug can derive the secret from the connection", ctx do
-      opts = VerifyTenantToken.init([])
-
-      conn =
-        :get
-        |> conn("/")
-        |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
-        |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
-        |> Pipeline.put_module(ctx.impl)
-        |> Pipeline.put_error_handler(ctx.handler)
-        |> VerifyTenantToken.call(opts)
-
-      refute conn.halted
-      assert Guardian.Plug.current_claims(conn, []) == ctx.tenant_claims
-    end
-
     test "a nil :secret fails closed instead of falling back to the module secret", ctx do
       conn = call_with(ctx, ctx.configured_token, secret: nil)
 
@@ -517,21 +487,6 @@ defmodule Guardian.Plug.VerifyHeaderTest do
 
       refute conn.halted
       assert Guardian.Plug.current_claims(conn, []) == ctx.tenant_claims
-    end
-
-    test "a wrapping plug can still derive the secret from the connection", ctx do
-      opts = VerifyTenantToken.init([])
-
-      conn =
-        :get
-        |> conn("/")
-        |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
-        |> Pipeline.put_module(ctx.impl)
-        |> Pipeline.put_error_handler(ctx.handler)
-        |> VerifyTenantToken.call(opts)
-
-      assert conn.status == 401
-      assert conn.resp_body == inspect({:invalid_token, :secret_not_found})
     end
   end
 end

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -374,6 +374,19 @@ defmodule Guardian.Plug.VerifyHeaderTest do
 
     def tenant_secret, do: @tenant_secret
 
+    def counted_secret(conn) do
+      send(self(), :secret_resolved)
+      conn.assigns[:tenant_secret]
+    end
+
+    defp resolve_count(n \\ 0) do
+      receive do
+        :secret_resolved -> resolve_count(n + 1)
+      after
+        0 -> n
+      end
+    end
+
     setup do
       impl = __MODULE__.SecretImpl
       handler = __MODULE__.Handler
@@ -464,6 +477,28 @@ defmodule Guardian.Plug.VerifyHeaderTest do
 
       assert conn.status == 401
       assert conn.resp_body == inspect({:invalid_token, :secret_not_found})
+    end
+
+    test "a connection aware :secret is resolved once per request", ctx do
+      :get
+      |> conn("/")
+      |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
+      |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
+      |> Pipeline.put_module(ctx.impl)
+      |> Pipeline.put_error_handler(ctx.handler)
+      |> VerifyHeader.call(VerifyHeader.init(secret: &__MODULE__.counted_secret/1))
+
+      assert resolve_count() == 1
+    end
+
+    test "a connection aware :secret is not resolved when no token is present", ctx do
+      :get
+      |> conn("/")
+      |> Pipeline.put_module(ctx.impl)
+      |> Pipeline.put_error_handler(ctx.handler)
+      |> VerifyHeader.call(VerifyHeader.init(secret: &__MODULE__.counted_secret/1))
+
+      assert resolve_count() == 0
     end
 
     test "a connection aware :secret survives a compiled plug pipeline", ctx do

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -501,6 +501,50 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       assert resolve_count() == 0
     end
 
+    test "a :secret on the plug is not inherited by :refresh_from_cookie", ctx do
+      {:ok, refresh_token, _} =
+        __MODULE__.SecretImpl.encode_and_sign(@resource, %{}, token_type: "refresh", secret: @tenant_secret)
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_cookie("guardian_default_token", refresh_token)
+        |> fetch_cookies()
+        |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifyHeader.call(VerifyHeader.init(secret: &__MODULE__.counted_secret/1, refresh_from_cookie: []))
+
+      assert conn.status == 401
+      assert conn.resp_body == inspect({:invalid_token, :invalid_token})
+      assert resolve_count() == 0
+    end
+
+    test "a :secret set on both the plug and :refresh_from_cookie is resolved for each", ctx do
+      {:ok, refresh_token, _} =
+        __MODULE__.SecretImpl.encode_and_sign(@resource, %{}, token_type: "refresh", secret: @tenant_secret)
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("authorization", "Bearer #{ctx.configured_token}")
+        |> put_req_cookie("guardian_default_token", refresh_token)
+        |> fetch_cookies()
+        |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifyHeader.call(
+          VerifyHeader.init(
+            secret: &__MODULE__.counted_secret/1,
+            refresh_from_cookie: [secret: &__MODULE__.counted_secret/1]
+          )
+        )
+
+      refute conn.halted
+      assert Guardian.Plug.current_claims(conn, [])["typ"] == "access"
+      assert resolve_count() == 2
+    end
+
     test "a connection aware :secret survives a compiled plug pipeline", ctx do
       defmodule TenantPipeline do
         @moduledoc false

--- a/test/guardian/plug/verify_header_test.exs
+++ b/test/guardian/plug/verify_header_test.exs
@@ -354,4 +354,133 @@ defmodule Guardian.Plug.VerifyHeaderTest do
       assert %{"sub" => "User:jane", "typ" => "access"} = Guardian.Plug.current_claims(conn)
     end
   end
+
+  describe "with a runtime secret" do
+    @configured_secret "configured-secret-key"
+    @tenant_secret "tenant-secret-key"
+
+    defmodule SecretImpl do
+      @moduledoc false
+
+      use Guardian,
+        otp_app: :guardian,
+        token_module: Guardian.Token.Jwt,
+        secret_key: "configured-secret-key",
+        allowed_algos: ["HS512"]
+
+      def subject_for_token(%{id: id}, _claims), do: {:ok, id}
+      def resource_from_claims(%{"sub" => id}), do: {:ok, %{id: id}}
+    end
+
+    defmodule TenantVerifyHeader do
+      @moduledoc false
+
+      @behaviour Plug
+
+      @impl Plug
+      def init(opts), do: VerifyHeader.init(opts)
+
+      @impl Plug
+      def call(conn, opts) do
+        VerifyHeader.call(conn, Keyword.put(opts, :secret, conn.assigns[:tenant_secret]))
+      end
+    end
+
+    def tenant_secret, do: @tenant_secret
+
+    setup do
+      impl = __MODULE__.SecretImpl
+      handler = __MODULE__.Handler
+
+      {:ok, tenant_token, tenant_claims} =
+        __MODULE__.SecretImpl.encode_and_sign(@resource, %{}, secret: @tenant_secret)
+
+      {:ok, configured_token, _} = __MODULE__.SecretImpl.encode_and_sign(@resource)
+
+      {:ok,
+       %{
+         impl: impl,
+         handler: handler,
+         tenant_token: tenant_token,
+         tenant_claims: tenant_claims,
+         configured_token: configured_token
+       }}
+    end
+
+    defp call_with(ctx, token, opts) do
+      :get
+      |> conn("/")
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> Pipeline.put_module(ctx.impl)
+      |> Pipeline.put_error_handler(ctx.handler)
+      |> VerifyHeader.call(VerifyHeader.init(opts))
+    end
+
+    test "the :secret option overrides the implementation module secret", ctx do
+      conn = call_with(ctx, ctx.tenant_token, secret: @tenant_secret)
+
+      refute conn.halted
+      assert Guardian.Plug.current_token(conn, []) == ctx.tenant_token
+      assert Guardian.Plug.current_claims(conn, []) == ctx.tenant_claims
+    end
+
+    test "the :secret option is resolved from an {m, f, a} tuple", ctx do
+      conn = call_with(ctx, ctx.tenant_token, secret: {__MODULE__, :tenant_secret, []})
+
+      refute conn.halted
+      assert Guardian.Plug.current_claims(conn, []) == ctx.tenant_claims
+    end
+
+    test "without the :secret option the implementation module secret is used", ctx do
+      conn = call_with(ctx, ctx.configured_token, [])
+
+      refute conn.halted
+      assert Guardian.Plug.current_token(conn, []) == ctx.configured_token
+    end
+
+    test "a token signed with another secret is rejected", ctx do
+      conn = call_with(ctx, ctx.tenant_token, secret: @configured_secret)
+
+      assert conn.status == 401
+      assert Guardian.Plug.current_token(conn, []) == nil
+    end
+
+    test "a wrapping plug can derive the secret from the connection", ctx do
+      opts = TenantVerifyHeader.init([])
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
+        |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> TenantVerifyHeader.call(opts)
+
+      refute conn.halted
+      assert Guardian.Plug.current_claims(conn, []) == ctx.tenant_claims
+    end
+
+    test "a nil :secret falls back to the implementation module secret", ctx do
+      conn = call_with(ctx, ctx.configured_token, secret: nil)
+
+      refute conn.halted
+      assert Guardian.Plug.current_token(conn, []) == ctx.configured_token
+    end
+
+    test "a wrapping plug that finds no secret does not verify the tenant token", ctx do
+      opts = TenantVerifyHeader.init([])
+
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("authorization", "Bearer #{ctx.tenant_token}")
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> TenantVerifyHeader.call(opts)
+
+      assert conn.status == 401
+      assert conn.resp_body == inspect({:invalid_token, :invalid_token})
+    end
+  end
 end

--- a/test/guardian/plug/verify_session_test.exs
+++ b/test/guardian/plug/verify_session_test.exs
@@ -385,5 +385,26 @@ defmodule Guardian.Plug.VerifySessionTest do
       assert conn.status == 401
       assert Guardian.Plug.current_token(conn, []) == nil
     end
+
+    test "the :secret option accepts a function of the connection", ctx do
+      conn =
+        :get
+        |> conn("/")
+        |> init_test_session(%{guardian_default_token: ctx.token})
+        |> Plug.Conn.assign(:tenant_secret, @tenant_secret)
+        |> Pipeline.put_module(ctx.impl)
+        |> Pipeline.put_error_handler(ctx.handler)
+        |> VerifySession.call(secret: & &1.assigns.tenant_secret)
+
+      refute conn.halted
+      assert Guardian.Plug.current_claims(conn, []) == ctx.claims
+    end
+
+    test "a connection aware :secret returning nil fails closed", ctx do
+      conn = call_with(ctx, secret: & &1.assigns[:tenant_secret])
+
+      assert conn.status == 401
+      assert conn.resp_body == inspect({:invalid_token, :secret_not_found})
+    end
   end
 end

--- a/test/guardian/plug/verify_session_test.exs
+++ b/test/guardian/plug/verify_session_test.exs
@@ -336,4 +336,54 @@ defmodule Guardian.Plug.VerifySessionTest do
       assert %{"sub" => "User:jane", "typ" => "access"} = Guardian.Plug.current_claims(conn)
     end
   end
+
+  describe "with a runtime secret" do
+    @tenant_secret "tenant-secret-key"
+
+    defmodule SecretImpl do
+      @moduledoc false
+
+      use Guardian,
+        otp_app: :guardian,
+        token_module: Guardian.Token.Jwt,
+        secret_key: "configured-secret-key",
+        allowed_algos: ["HS512"]
+
+      def subject_for_token(%{id: id}, _claims), do: {:ok, id}
+      def resource_from_claims(%{"sub" => id}), do: {:ok, %{id: id}}
+    end
+
+    setup do
+      impl = __MODULE__.SecretImpl
+      handler = __MODULE__.Handler
+
+      {:ok, token, claims} = __MODULE__.SecretImpl.encode_and_sign(@resource, %{}, secret: @tenant_secret)
+
+      {:ok, %{impl: impl, handler: handler, token: token, claims: claims}}
+    end
+
+    defp call_with(ctx, opts) do
+      :get
+      |> conn("/")
+      |> init_test_session(%{guardian_default_token: ctx.token})
+      |> Pipeline.put_module(ctx.impl)
+      |> Pipeline.put_error_handler(ctx.handler)
+      |> VerifySession.call(opts)
+    end
+
+    test "the :secret option overrides the implementation module secret", ctx do
+      conn = call_with(ctx, secret: @tenant_secret)
+
+      refute conn.halted
+      assert Guardian.Plug.current_token(conn, []) == ctx.token
+      assert Guardian.Plug.current_claims(conn, []) == ctx.claims
+    end
+
+    test "without the :secret option the token is rejected", ctx do
+      conn = call_with(ctx, [])
+
+      assert conn.status == 401
+      assert Guardian.Plug.current_token(conn, []) == nil
+    end
+  end
 end

--- a/test/guardian/plug_test.exs
+++ b/test/guardian/plug_test.exs
@@ -715,6 +715,57 @@ defmodule Guardian.PlugTest do
     end
   end
 
+  describe "#resolve_secret" do
+    def tenant_secret, do: "from-an-mfa-tuple"
+
+    setup do
+      {:ok, %{conn: conn(:get, "/") |> assign(:tenant_secret, "from-the-conn")}}
+    end
+
+    test "leaves options without a :secret untouched", ctx do
+      opts = [key: :default, allowed_algos: ["HS512"]]
+      assert Guardian.Plug.resolve_secret(ctx.conn, opts) == opts
+    end
+
+    test "leaves a static :secret untouched", ctx do
+      opts = [secret: "static", key: :default]
+      assert Guardian.Plug.resolve_secret(ctx.conn, opts) == opts
+    end
+
+    test "leaves an {m, f, a} :secret untouched", ctx do
+      opts = [secret: {__MODULE__, :tenant_secret, []}]
+      assert Guardian.Plug.resolve_secret(ctx.conn, opts) == opts
+    end
+
+    test "calls a one argument :secret with the connection", ctx do
+      opts = [secret: & &1.assigns.tenant_secret, key: :default]
+
+      assert Guardian.Plug.resolve_secret(ctx.conn, opts) == [secret: "from-the-conn", key: :default]
+    end
+
+    test "keeps an explicit nil rather than dropping the option", ctx do
+      opts = Guardian.Plug.resolve_secret(ctx.conn, secret: fn _conn -> nil end)
+
+      assert Keyword.fetch(opts, :secret) == {:ok, nil}
+    end
+
+    test "raises on a :secret function of the wrong arity", ctx do
+      assert_raise ArgumentError, ~r/must be a function of one argument/, fn ->
+        Guardian.Plug.resolve_secret(ctx.conn, secret: fn -> "nope" end)
+      end
+
+      assert_raise ArgumentError, ~r/must be a function of one argument/, fn ->
+        Guardian.Plug.resolve_secret(ctx.conn, secret: fn _conn, _opts -> "nope" end)
+      end
+    end
+
+    test "lets an exception from the resolver through", ctx do
+      assert_raise KeyError, fn ->
+        Guardian.Plug.resolve_secret(ctx.conn, secret: & &1.assigns.missing)
+      end
+    end
+  end
+
   describe "#keys" do
     alias Guardian.Plug.Keys
 

--- a/test/guardian/token/jwt_test.exs
+++ b/test/guardian/token/jwt_test.exs
@@ -587,4 +587,77 @@ defmodule Guardian.Token.JwtTest do
       assert_received({:secret_fetcher, _headers})
     end
   end
+
+  describe "with a secret fetcher that inherits the defaults" do
+    defmodule InheritedFetcher do
+      @moduledoc false
+      use Guardian.Token.Jwt.SecretFetcher
+    end
+
+    defmodule InheritedImpl do
+      @moduledoc false
+
+      use Guardian,
+        otp_app: :guardian,
+        token_module: Guardian.Token.Jwt,
+        secret_key: "inherited-secret-key",
+        allowed_algos: ["HS512"],
+        secret_fetcher: Guardian.Token.JwtTest.InheritedFetcher
+
+      def subject_for_token(%{id: id}, _claims), do: {:ok, id}
+      def resource_from_claims(%{"sub" => id}), do: {:ok, %{id: id}}
+    end
+
+    @resource %{id: "bobby"}
+
+    setup do
+      {:ok, token, _claims} = InheritedImpl.encode_and_sign(@resource)
+      {:ok, %{token: token}}
+    end
+
+    test "falls back to the configured secret_key when :secret is absent", ctx do
+      assert {:ok, _claims} = Guardian.decode_and_verify(InheritedImpl, ctx.token, %{})
+    end
+
+    test "fails closed on a nil :secret rather than falling back", ctx do
+      assert {:error, :secret_not_found} =
+               Guardian.decode_and_verify(InheritedImpl, ctx.token, %{}, secret: nil)
+
+      assert {:error, :secret_not_found} =
+               Guardian.encode_and_sign(InheritedImpl, @resource, %{}, secret: nil)
+    end
+
+    test "honours an explicit :secret", ctx do
+      assert {:error, :invalid_token} =
+               Guardian.decode_and_verify(InheritedImpl, ctx.token, %{}, secret: "another-key")
+    end
+  end
+
+  describe "a missing secret through the public API" do
+    @resource %{id: "1"}
+
+    test "encode_and_sign reports it", ctx do
+      assert {:error, :secret_not_found} = Guardian.encode_and_sign(ctx.impl, @resource, %{}, secret: nil)
+    end
+
+    test "decode_and_verify reports it", ctx do
+      assert {:error, :secret_not_found} = Guardian.decode_and_verify(ctx.impl, ctx.jwt, %{}, secret: nil)
+    end
+
+    test "resource_from_token reports it", ctx do
+      assert {:error, :secret_not_found} = Guardian.resource_from_token(ctx.impl, ctx.jwt, %{}, secret: nil)
+    end
+
+    test "revoke reports it", ctx do
+      assert {:error, :secret_not_found} = Guardian.revoke(ctx.impl, ctx.jwt, secret: nil)
+    end
+
+    test "refresh reports it", ctx do
+      assert {:error, :secret_not_found} = Guardian.refresh(ctx.impl, ctx.jwt, secret: nil)
+    end
+
+    test "exchange reports it", ctx do
+      assert {:error, :secret_not_found} = Guardian.exchange(ctx.impl, ctx.jwt, "access", "refresh", secret: nil)
+    end
+  end
 end

--- a/test/guardian/token/jwt_test.exs
+++ b/test/guardian/token/jwt_test.exs
@@ -165,6 +165,11 @@ defmodule Guardian.Token.JwtTest do
 
       assert jwt.fields == ctx.claims
     end
+
+    test "a nil secret does not fall back to the configured secret_key", ctx do
+      assert ctx.impl.config(:secret_key)
+      assert {:error, :secret_not_found} == Jwt.create_token(ctx.impl, ctx.claims, secret: nil)
+    end
   end
 
   describe "decode_token" do
@@ -196,6 +201,20 @@ defmodule Guardian.Token.JwtTest do
       secret = {ctx.impl, :the_secret_yo, [the_secret]}
       result = Jwt.decode_token(ctx.impl, ctx.jwt, secret: secret)
       assert {:ok, ctx.claims} == result
+    end
+
+    test "a nil secret does not fall back to the configured secret_key", ctx do
+      assert ctx.impl.config(:secret_key)
+      assert {:error, :secret_not_found} == Jwt.decode_token(ctx.impl, ctx.jwt, secret: nil)
+    end
+
+    test "an {m, f, a} resolving to nil does not fall back to the configured secret_key", ctx do
+      secret = {ctx.impl, :the_secret_yo, [nil]}
+      assert {:error, :secret_not_found} == Jwt.decode_token(ctx.impl, ctx.jwt, secret: secret)
+    end
+
+    test "an absent secret still falls back to the configured secret_key", ctx do
+      assert {:ok, ctx.claims} == Jwt.decode_token(ctx.impl, ctx.jwt)
     end
   end
 


### PR DESCRIPTION
Closes #690.

- Selecting a verifying secret per request was only possible by wrapping each verify plug, a pattern with a non-obvious trap: you must delegate to the wrapped plug's `init/1` or `:scheme_reg` is never compiled, the fallback regex matches the whole header including `Bearer `, and every token silently fails to verify. Accepting a one argument function for `:secret` removes the need for the wrapper in the case that actually motivated the issue.
- An MFA was the obvious encoding, but it is the one form that was unsafe to use: `Guardian.Config.resolve_value/1` already defines `{m, f, a}` as `apply(m, f, a)` with no connection, and that already works in plug options today. Injecting the connection would give the same tuple two meanings depending on where it was written. A one argument function had no prior meaning, so it was free to claim.
- The `nil` fallback is the reason this is not a docs-only change. `Config.resolve_value(secret) || mod.config(:secret_key)` treated an explicit `nil` as absent, so a tenant lookup that quietly failed would sign or verify with the application wide secret rather than reject. That is a tenant isolation failure, not a failed request, for anyone whose implementation module handles both third party and self issued tokens. Omitting `:secret` still falls back as before; only an explicit `nil` now fails.
- `decode_token/3` collapsed every non-signature failure into `:invalid_token`, which would have made the new fail-closed path indistinguishable from a bad signature and left misconfigured runtime secrets undebuggable.

Two behaviour changes are called out in the CHANGELOG: the `nil` fallback removal, and `:secret_not_found` now reaching error handlers that previously saw `:invalid_token`.