### PR TITLE
chore: release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v2.5.0
 
 ### Added
 
@@ -17,6 +17,13 @@
   `ArgumentError` instead of reaching the token module.
 
 ### Changed
+
+* **Behaviour change.** `Guardian.Token.Jwt.Verify` rejects `exp`, `nbf` and
+  `auth_time` claims that are not numbers, and
+  `Guardian.Token.Verify.time_within_drift?/2` returns `false` instead of
+  `true` for a non-numeric time. Previously a token carrying a string or
+  boolean in a time claim passed the drift check and was accepted as valid
+  ([#745](https://github.com/ueberauth/guardian/pull/745)).
 
 * **Behaviour change.** `Guardian.Token.Jwt` no longer falls back to the
   implementation module's `:secret_key` when an explicitly provided `:secret`

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Guardian.Mixfile do
   use Mix.Project
 
   @app :guardian
-  @version "2.4.1"
+  @version "2.5.0"
   @url "https://github.com/ueberauth/guardian"
   @maintainers [
     "Daniel Neighman",


### PR DESCRIPTION
- Two behaviour changes landed since v2.4.1 (non-numeric time claims now rejected, and a nil `:secret` no longer falls back to `secret_key`), so consumers need a version boundary they can pin against and a changelog entry that names both.
- The non-numeric time claim change in #745 shipped without a changelog entry, which would have left the behaviour change undocumented at release time.
- Minor rather than major, matching how v2.4.1 shipped comparable security-driven behaviour changes.