### PR TITLE
docs: add markdown formatter to docs output

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule Guardian.Mixfile do
       main: "readme",
       extra_section: "guides",
       assets: %{"guides/assets" => "assets"},
-      formatters: ["html", "epub"],
+      formatters: ["html", "markdown", "epub"],
       groups_for_modules: groups_for_modules(),
       extras: extras(),
       groups_for_extras: groups_for_extras()


### PR DESCRIPTION
ex_doc v0.40.0 added a Markdown formatter and generates `llms.txt` by default. Because this project pins an explicit `formatters:` list, that default does not apply.

This adds `"markdown"` while preserving the existing HTML and EPUB formatters. Verified all three outputs with `mix docs`, plus `mix format --check-formatted`, `mix credo`, and `mix test` (284 tests, 0 failures).

Generated from the findings in [Elixir's retrieval gap is a rollout problem, not an access problem](https://phxagents.dev/research/elixir-retrieval-gap/).

— Oliver’s AMP